### PR TITLE
Plugged socket session into JSONRPCtransport

### DIFF
--- a/Sources/WalletConnect/Relay/Relay.swift
+++ b/Sources/WalletConnect/Relay/Relay.swift
@@ -84,7 +84,7 @@ class Relay {
     }
     
     private func setUpTransport() {
-        transport.onPayload = { [unowned self] payload in
+        transport.onMessage = { [unowned self] payload in
             self.onPayload(payload)
         }
     }

--- a/Tests/WalletConnectTests/Mocks/MockedJSONRPCTransport.swift
+++ b/Tests/WalletConnectTests/Mocks/MockedJSONRPCTransport.swift
@@ -4,9 +4,9 @@ import Foundation
 @testable import WalletConnect
 
 class MockedJSONRPCTransport: JSONRPCTransporting {
-    var onConnected: (() -> ())?
-    var onDisconnected: (() -> ())?
-    var onPayload: ((String) -> ())?
+    var onConnect: (() -> ())?
+    var onDisconnect: (() -> ())?
+    var onMessage: ((String) -> ())?
     var send = false
     func send(_ string: String, completion: @escaping (Error?) -> ()) {
         send = true

--- a/Tests/WalletConnectTests/RelayTests.swift
+++ b/Tests/WalletConnectTests/RelayTests.swift
@@ -30,7 +30,7 @@ class RelayTests: XCTestCase {
         subscriber.topic = topic
         crypto.set(agreementKeys: Crypto.X25519.AgreementKeys(sharedSecret: Data(), publicKey: Data()), topic: topic)
         relay.addSubscriber(subscriber)
-        transport.onPayload?(testPayload)
+        transport.onMessage?(testPayload)
         XCTAssertTrue(subscriber.notified)
     }
     


### PR DESCRIPTION
closes #20

Plug web socket session into JSONRPCTransport.

Next Steps: Relay API methods request-response handling in the transport.