### PR TITLE
#31 relay subscribe interface

### DIFF
--- a/Sources/WalletConnect/JSONRPC/JSONRPC.swift
+++ b/Sources/WalletConnect/JSONRPC/JSONRPC.swift
@@ -28,7 +28,7 @@ struct JSONRPCRequest<T: Codable>: Codable {
     }
 
     private static func generateId() -> Int64 {
-        return Int64(Date().timeIntervalSince1970 * 1000)
+        return Int64(Date().timeIntervalSince1970 * 1000)*1000 + Int64.random(in: 0..<1000)
     }
 }
 

--- a/Sources/WalletConnect/Relay/RelaySubscriber.swift
+++ b/Sources/WalletConnect/Relay/RelaySubscriber.swift
@@ -2,7 +2,6 @@
 import Foundation
 
 protocol RelaySubscriber: class {
-    var relay: Relay! { get }
     func onRequest(_ jsonRpcRequest: ClientSynchJSONRPC)
     func onResponse(requestId: String, responseType: Relay.SubscriberResponseType)
     func isSubscribing(for subscriptionId: String) -> Bool

--- a/Sources/WalletConnect/Relay/RelaySubscriber.swift
+++ b/Sources/WalletConnect/Relay/RelaySubscriber.swift
@@ -1,8 +1,19 @@
-// 
 
 import Foundation
 
 protocol RelaySubscriber: class {
-    var topic: String {get set}
-    func update(with jsonRpcRequest: ClientSynchJSONRPC)
+    var relay: Relay! { get }
+    func onRequest(_ jsonRpcRequest: ClientSynchJSONRPC)
+    func onResponse(requestId: String, responseType: Relay.SubscriberResponseType)
+    func isSubscribing(for subscriptionId: String) -> Bool
+    func hasPendingRequest(id: Int64) -> Bool
+    func set(pendingRequestId: Int64)
+}
+
+extension Relay {
+    enum SubscriberResponseType {
+        case requestAcknowledge
+        case error(Error)
+        case subscriptionAcknowledge(String)
+    }
 }

--- a/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC.swift
+++ b/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC.swift
@@ -105,6 +105,6 @@ struct ClientSynchJSONRPC: Codable {
     }
     
     private static func generateId() -> Int64 {
-        return Int64(Date().timeIntervalSince1970 * 1000)
+        return Int64(Date().timeIntervalSince1970 * 1000)*1000 + Int64.random(in: 0..<1000)
     }
 }

--- a/Tests/WalletConnectTests/Mocks/MockedRelaySubscriber.swift
+++ b/Tests/WalletConnectTests/Mocks/MockedRelaySubscriber.swift
@@ -1,13 +1,29 @@
-// 
 
 import Foundation
 @testable import WalletConnect
 
-
 class MockedRelaySubscriber: RelaySubscriber {
-    var topic: String = ""
+    var relay: Relay!
+    var subscriptionIds = [String]()
+    var pendingRequestsIds = [Int64]()
     var notified = false
-    func update(with jsonRpcRequest: ClientSynchJSONRPC) {
+    
+    func onRequest(_ jsonRpcRequest: ClientSynchJSONRPC) {
         notified = true
+    }
+    
+    func onResponse(requestId: String, responseType: Relay.SubscriberResponseType) {
+    }
+    
+    func isSubscribing(for subscriptionId: String) -> Bool {
+        return subscriptionIds.contains(subscriptionId)
+    }
+    
+    func hasPendingRequest(id: Int64) -> Bool {
+        return pendingRequestsIds.contains(id)
+    }
+    
+    func set(pendingRequestId: Int64) {
+        pendingRequestsIds.append(pendingRequestId)
     }
 }

--- a/Tests/WalletConnectTests/Mocks/MockedRelaySubscriber.swift
+++ b/Tests/WalletConnectTests/Mocks/MockedRelaySubscriber.swift
@@ -3,7 +3,6 @@ import Foundation
 @testable import WalletConnect
 
 class MockedRelaySubscriber: RelaySubscriber {
-    var relay: Relay!
     var subscriptionIds = [String]()
     var pendingRequestsIds = [Int64]()
     var notified = false

--- a/Tests/WalletConnectTests/RelayTests.swift
+++ b/Tests/WalletConnectTests/RelayTests.swift
@@ -23,11 +23,12 @@ class RelayTests: XCTestCase {
         serialiser = nil
     }
     
-    func testNotifySubscriberOnPayload() {
+    func testNotifySubscriberOnWakuSubscriptionPayload() {
         let topic = "fefc3dc39cacbc562ed58f92b296e2d65a6b07ef08992b93db5b3cb86280635a"
+        let subscriptionId = "0847f4e1dd19cf03a43dc7525f39896b630e9da33e4683c8efbc92ea671b5e07"
         serialiser.deserialised = SerialiserTestData.pairingApproveJSONRPCRequest
         let subscriber = MockedRelaySubscriber()
-        subscriber.topic = topic
+        subscriber.subscriptionIds.append(subscriptionId)
         crypto.set(agreementKeys: Crypto.X25519.AgreementKeys(sharedSecret: Data(), publicKey: Data()), topic: topic)
         relay.addSubscriber(subscriber)
         transport.onPayload?(testPayload)
@@ -35,7 +36,8 @@ class RelayTests: XCTestCase {
     }
     
     func testSendOnPublish() {
-        relay.publish(topic: "", payload: "")
+        let subscriber = MockedRelaySubscriber()
+        relay.publish(topic: "", payload: "", subscriber: subscriber)
         XCTAssertTrue(transport.send)
     }
 }


### PR DESCRIPTION
close #31 
@MisterVants  do not want to conflict with you so, just replaced old subscriber method calls in `Relay`.  And I think it should be useful to have this interface before response deserialisation.