### PR TITLE
#71 session list

### DIFF
--- a/Example/ExampleApp.xcodeproj/project.pbxproj
+++ b/Example/ExampleApp.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		764E1D4C26F8D3FE00A1FB15 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 764E1D4A26F8D3FE00A1FB15 /* LaunchScreen.storyboard */; };
 		764E1D5826F8DBAB00A1FB15 /* WalletConnect in Frameworks */ = {isa = PBXBuildFile; productRef = 764E1D5726F8DBAB00A1FB15 /* WalletConnect */; };
 		764E1D5A26F8DF1B00A1FB15 /* ScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764E1D5926F8DF1B00A1FB15 /* ScannerViewController.swift */; };
+		76744CF526FDFB6B00B77ED9 /* ResponderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76744CF426FDFB6B00B77ED9 /* ResponderView.swift */; };
+		76744CF726FE4D5400B77ED9 /* ActiveSessionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76744CF626FE4D5400B77ED9 /* ActiveSessionItem.swift */; };
+		76744CF926FE4D7400B77ED9 /* ActiveSessionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76744CF826FE4D7400B77ED9 /* ActiveSessionCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +39,9 @@
 		764E1D5526F8DADE00A1FB15 /* WalletConnectSwiftV2 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = WalletConnectSwiftV2; path = ..; sourceTree = "<group>"; };
 		764E1D5626F8DB6000A1FB15 /* WalletConnectSwiftV2 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = WalletConnectSwiftV2; path = ..; sourceTree = "<group>"; };
 		764E1D5926F8DF1B00A1FB15 /* ScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerViewController.swift; sourceTree = "<group>"; };
+		76744CF426FDFB6B00B77ED9 /* ResponderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponderView.swift; sourceTree = "<group>"; };
+		76744CF626FE4D5400B77ED9 /* ActiveSessionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSessionItem.swift; sourceTree = "<group>"; };
+		76744CF826FE4D7400B77ED9 /* ActiveSessionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSessionCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,6 +60,9 @@
 			isa = PBXGroup;
 			children = (
 				761C649B26FB7B7F004239D1 /* ResponderViewController.swift */,
+				76744CF426FDFB6B00B77ED9 /* ResponderView.swift */,
+				76744CF826FE4D7400B77ED9 /* ActiveSessionCell.swift */,
+				76744CF626FE4D5400B77ED9 /* ActiveSessionItem.swift */,
 				764E1D5926F8DF1B00A1FB15 /* ScannerViewController.swift */,
 				761C64A426FCB08B004239D1 /* Session */,
 			);
@@ -192,11 +201,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				761C64A326FB83CE004239D1 /* SessionView.swift in Sources */,
+				76744CF526FDFB6B00B77ED9 /* ResponderView.swift in Sources */,
 				761C649A26FB7ABB004239D1 /* ProposerViewController.swift in Sources */,
+				76744CF926FE4D7400B77ED9 /* ActiveSessionCell.swift in Sources */,
 				764E1D4026F8D3FC00A1FB15 /* AppDelegate.swift in Sources */,
 				761C649C26FB7B7F004239D1 /* ResponderViewController.swift in Sources */,
 				761C64A626FCB0AA004239D1 /* SessionInfo.swift in Sources */,
 				761C649E26FB7FD7004239D1 /* SessionViewController.swift in Sources */,
+				76744CF726FE4D5400B77ED9 /* ActiveSessionItem.swift in Sources */,
 				764E1D4226F8D3FC00A1FB15 /* SceneDelegate.swift in Sources */,
 				764E1D5A26F8DF1B00A1FB15 /* ScannerViewController.swift in Sources */,
 			);

--- a/Example/ExampleApp/Responder/ActiveSessionCell.swift
+++ b/Example/ExampleApp/Responder/ActiveSessionCell.swift
@@ -33,6 +33,7 @@ final class ActiveSessionCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         accessoryType = .disclosureIndicator
+        selectionStyle = .none
         
         contentView.addSubview(iconView)
         contentView.addSubview(titleLabel)

--- a/Example/ExampleApp/Responder/ActiveSessionCell.swift
+++ b/Example/ExampleApp/Responder/ActiveSessionCell.swift
@@ -1,0 +1,77 @@
+import UIKit
+
+final class ActiveSessionCell: UITableViewCell {
+    
+    var item: ActiveSessionItem? {
+        didSet {
+            if let item = item {
+                show(item)
+            }
+        }
+    }
+    
+    private let iconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.layer.cornerRadius = 20
+        return imageView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        return label
+    }()
+    
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .caption1)
+        label.textColor = .secondaryLabel
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        accessoryType = .disclosureIndicator
+        
+        contentView.addSubview(iconView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(subtitleLabel)
+        
+        contentView.subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+        
+        NSLayoutConstraint.activate([
+            iconView.heightAnchor.constraint(equalToConstant: 40),
+            iconView.heightAnchor.constraint(equalTo: iconView.widthAnchor),
+            iconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+            titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.lastBaselineAnchor, constant: 6),
+            subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            subtitleLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            subtitleLabel.lastBaselineAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12)
+        ])
+    }
+    
+    private func show(_ item: ActiveSessionItem) {
+        titleLabel.text = item.dappName
+        subtitleLabel.text = item.dappURL
+        iconView.image = nil
+        guard let iconURL = URL(string: item.iconURL) else { return }
+        DispatchQueue.global().async {
+            if let imageData = try? Data(contentsOf: iconURL) {
+                DispatchQueue.main.async { [weak self] in
+                    self?.iconView.image = UIImage(data: imageData)
+                }
+            }
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Example/ExampleApp/Responder/ActiveSessionItem.swift
+++ b/Example/ExampleApp/Responder/ActiveSessionItem.swift
@@ -1,0 +1,36 @@
+struct ActiveSessionItem {
+    let dappName: String
+    let dappURL: String
+    let iconURL: String
+}
+
+extension ActiveSessionItem {
+    
+    static func mockList() -> [ActiveSessionItem] {
+        [mockPancakeSwap(), mockUniswap(), mockSushiSwap()]
+    }
+    
+    static func mockPancakeSwap() -> ActiveSessionItem {
+        ActiveSessionItem(
+            dappName: "PancakeSwap",
+            dappURL: "pancakeswap.finance",
+            iconURL: "https://pancakeswap.finance/logo.png"
+        )
+    }
+    
+    static func mockUniswap() -> ActiveSessionItem {
+        ActiveSessionItem(
+            dappName: "Uniswap",
+            dappURL: "app.uniswap.org",
+            iconURL: "https://s2.coinmarketcap.com/static/img/coins/64x64/7083.png"
+        )
+    }
+    
+    static func mockSushiSwap() -> ActiveSessionItem {
+        ActiveSessionItem(
+            dappName: "Sushi Swap",
+            dappURL: "app.sushi.com",
+            iconURL: "https://s2.coinmarketcap.com/static/img/coins/64x64/6758.png"
+        )
+    }
+}

--- a/Example/ExampleApp/Responder/ResponderView.swift
+++ b/Example/ExampleApp/Responder/ResponderView.swift
@@ -8,41 +8,21 @@ final class ResponderView: UIView {
         return tableView
     }()
     
-    var items: [ActiveSessionItem] = ActiveSessionItem.mockList()
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .systemBackground
         
         addSubview(tableView)
-        
         subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
-        
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
             tableView.leadingAnchor.constraint(equalTo: leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
         ])
-        
-        tableView.dataSource = self
-        tableView.delegate = self
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-}
-
-extension ResponderView: UITableViewDataSource, UITableViewDelegate {
-    
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        items.count
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "sessionCell", for: indexPath) as! ActiveSessionCell
-        cell.item = items[indexPath.row]
-        return cell
     }
 }

--- a/Example/ExampleApp/Responder/ResponderView.swift
+++ b/Example/ExampleApp/Responder/ResponderView.swift
@@ -1,0 +1,48 @@
+import UIKit
+
+final class ResponderView: UIView {
+    
+    let tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.register(ActiveSessionCell.self, forCellReuseIdentifier: "sessionCell")
+        return tableView
+    }()
+    
+    var items: [ActiveSessionItem] = ActiveSessionItem.mockList()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        
+        addSubview(tableView)
+        
+        subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
+        ])
+        
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension ResponderView: UITableViewDataSource, UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        items.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "sessionCell", for: indexPath) as! ActiveSessionCell
+        cell.item = items[indexPath.row]
+        return cell
+    }
+}

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -13,6 +13,8 @@ final class ResponderViewController: UIViewController {
         return WalletConnectClient(options: options)
     }()
     
+    var sessionItems: [ActiveSessionItem] = []
+    
     private let responderView: ResponderView = {
         ResponderView()
     }()
@@ -31,6 +33,10 @@ final class ResponderViewController: UIViewController {
             target: self,
             action: #selector(showScanner)
         )
+        
+        responderView.tableView.dataSource = self
+        responderView.tableView.delegate = self
+        sessionItems = ActiveSessionItem.mockList()
     }
     
     @objc
@@ -45,6 +51,34 @@ final class ResponderViewController: UIViewController {
         proposalViewController.delegate = self
         proposalViewController.show(SessionInfo.mock())
         present(proposalViewController, animated: true)
+    }
+}
+
+extension ResponderViewController: UITableViewDataSource, UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        sessionItems.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "sessionCell", for: indexPath) as! ActiveSessionCell
+        cell.item = sessionItems[indexPath.row]
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            sessionItems.remove(at: indexPath.row)
+            tableView.deleteRows(at: [indexPath], with: .automatic)
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
+        "Disconnect"
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        print("did select row \(indexPath)")
     }
 }
 

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -13,10 +13,17 @@ final class ResponderViewController: UIViewController {
         return WalletConnectClient(options: options)
     }()
     
+    private let responderView: ResponderView = {
+        ResponderView()
+    }()
+    
+    override func loadView() {
+        view = responderView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = "Wallet"
-        view.backgroundColor = .systemBackground
         
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             image: UIImage(systemName: "qrcode.viewfinder"),


### PR DESCRIPTION
closes #71

Adds a list of active sessions to the example app using mocked content, for now, with a swipe-to-delete interaction to trigger session disconnection calls in the future.

![list-example](https://user-images.githubusercontent.com/11507519/134733723-f4f3649c-a82c-4967-ba2d-6b18191c47ae.png)

