### PR TITLE
#90 pairings list

### DIFF
--- a/Example/ExampleApp/Proposer/ProposerView.swift
+++ b/Example/ExampleApp/Proposer/ProposerView.swift
@@ -19,12 +19,20 @@ final class ProposerView: UIView {
         return button
     }()
     
+    let tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.backgroundColor = .tertiarySystemBackground
+        tableView.register(ActiveSessionCell.self, forCellReuseIdentifier: "sessionCell")
+        return tableView
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .systemBackground
         
         addSubview(qrCodeView)
         addSubview(copyButton)
+        addSubview(tableView)
         
         subviews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
         
@@ -37,7 +45,12 @@ final class ProposerView: UIView {
             copyButton.topAnchor.constraint(equalTo: qrCodeView.bottomAnchor, constant: 16),
             copyButton.centerXAnchor.constraint(equalTo: centerXAnchor),
             copyButton.widthAnchor.constraint(equalTo: qrCodeView.widthAnchor),
-            copyButton.heightAnchor.constraint(equalToConstant: 44)
+            copyButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            tableView.topAnchor.constraint(equalTo: copyButton.bottomAnchor, constant: 16),
+            tableView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
         ])
     }
     

--- a/Example/ExampleApp/Proposer/ProposerViewController.swift
+++ b/Example/ExampleApp/Proposer/ProposerViewController.swift
@@ -143,7 +143,8 @@ extension ProposerViewController: WalletConnectClientDelegate {
             return ActiveSessionItem(
                 dappName: app?.name ?? "",
                 dappURL: app?.url ?? "",
-                iconURL: app?.icons?.first ?? "")
+                iconURL: app?.icons?.first ?? "",
+                topic: pairing.topic)
         }
         DispatchQueue.main.async {
             self.activeItems = activePairings

--- a/Example/ExampleApp/Proposer/ProposerViewController.swift
+++ b/Example/ExampleApp/Proposer/ProposerViewController.swift
@@ -17,6 +17,7 @@ final class ProposerViewController: UIViewController {
         return WalletConnectClient(options: options)
     }()
     
+    var activeItems: [ActiveSessionItem] = []
     private var currentURI: String?
     
     private let proposerView: ProposerView = {
@@ -40,6 +41,9 @@ final class ProposerViewController: UIViewController {
         
         proposerView.copyButton.addTarget(self, action: #selector(copyURI), for: .touchUpInside)
         proposerView.copyButton.isHidden = true
+        
+        proposerView.tableView.dataSource = self
+        proposerView.tableView.delegate = self
         
         client.delegate = self
     }
@@ -89,6 +93,34 @@ final class ProposerViewController: UIViewController {
     }
 }
 
+extension ProposerViewController: UITableViewDataSource, UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        activeItems.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "sessionCell", for: indexPath) as! ActiveSessionCell
+        cell.item = activeItems[indexPath.row]
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            activeItems.remove(at: indexPath.row)
+            tableView.deleteRows(at: [indexPath], with: .automatic)
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
+        "Disconnect"
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        print("did select row \(indexPath)")
+    }
+}
+
 extension ProposerViewController: WalletConnectClientDelegate {
     
     func didReceive(sessionProposal: SessionType.Proposal) {
@@ -105,6 +137,20 @@ extension ProposerViewController: WalletConnectClientDelegate {
     
     func didSettle(pairing: PairingType.Settled) {
         print("[PROPOSER] WC: Did settle pairing")
+        let settledPairings = client.getSettledPairings()
+        let activePairings = settledPairings.map { pairing -> ActiveSessionItem in
+            let app = pairing.peer.metadata
+            return ActiveSessionItem(
+                dappName: app?.name ?? "",
+                dappURL: app?.url ?? "",
+                iconURL: app?.icons?.first ?? "")
+        }
+        DispatchQueue.main.async {
+            self.activeItems = activePairings
+            self.proposerView.tableView.reloadData()
+            self.proposerView.qrCodeView.image = nil
+            self.proposerView.copyButton.isHidden = true
+        }
     }
     
     func didReject(sessionPendingTopic: String, reason: SessionType.Reason) {

--- a/Example/ExampleApp/Responder/ActiveSessionItem.swift
+++ b/Example/ExampleApp/Responder/ActiveSessionItem.swift
@@ -2,6 +2,7 @@ struct ActiveSessionItem {
     let dappName: String
     let dappURL: String
     let iconURL: String
+    let topic: String
 }
 
 extension ActiveSessionItem {
@@ -14,7 +15,8 @@ extension ActiveSessionItem {
         ActiveSessionItem(
             dappName: "PancakeSwap",
             dappURL: "pancakeswap.finance",
-            iconURL: "https://pancakeswap.finance/logo.png"
+            iconURL: "https://pancakeswap.finance/logo.png",
+            topic: ""
         )
     }
     
@@ -22,7 +24,8 @@ extension ActiveSessionItem {
         ActiveSessionItem(
             dappName: "Uniswap",
             dappURL: "app.uniswap.org",
-            iconURL: "https://s2.coinmarketcap.com/static/img/coins/64x64/7083.png"
+            iconURL: "https://s2.coinmarketcap.com/static/img/coins/64x64/7083.png",
+            topic: ""
         )
     }
     
@@ -30,7 +33,8 @@ extension ActiveSessionItem {
         ActiveSessionItem(
             dappName: "Sushi Swap",
             dappURL: "app.sushi.com",
-            iconURL: "https://s2.coinmarketcap.com/static/img/coins/64x64/6758.png"
+            iconURL: "https://s2.coinmarketcap.com/static/img/coins/64x64/6758.png",
+            topic: ""
         )
     }
 }

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -88,6 +88,9 @@ extension ResponderViewController: UITableViewDataSource, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
+            let item = sessionItems[indexPath.row]
+            let deleteParams = SessionType.DeleteParams(topic: item.topic, reason: SessionType.Reason(code: 0, message: "disconnect"))
+            client.disconnect(params: deleteParams)
             sessionItems.remove(at: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .automatic)
         }
@@ -120,6 +123,9 @@ extension ResponderViewController: SessionViewControllerDelegate {
     
     func didRejectSession() {
         print("did reject session")
+        let proposal = currentProposal!
+        currentProposal = nil
+        client.reject(proposal: proposal, reason: SessionType.Reason(code: 0, message: "reject"))
     }
 }
 
@@ -153,7 +159,8 @@ extension ResponderViewController: WalletConnectClientDelegate {
             return ActiveSessionItem(
                 dappName: app?.name ?? "",
                 dappURL: app?.url ?? "",
-                iconURL: app?.icons?.first ?? "")
+                iconURL: app?.icons?.first ?? "",
+                topic: session.topic)
         }
         DispatchQueue.main.async { // FIXME: Delegate being called from background thread
             self.sessionItems = activeSessions

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -8,7 +8,11 @@ final class ResponderViewController: UIViewController {
             apiKey: "",
             name: "Example Responder",
             isController: true,
-            metadata: AppMetadata(name: "Example Wallet", description: nil, url: nil, icons: nil),
+            metadata: AppMetadata(
+                name: "Example Wallet",
+                description: "wallet description",
+                url: "example.wallet",
+                icons: ["https://gblobscdn.gitbook.com/spaces%2F-LJJeCjcLrr53DcT1Ml7%2Favatar.png?alt=media"]),
             relayURL: URL(string: "wss://staging.walletconnect.org")!)
         return WalletConnectClient(options: options)
     }()
@@ -144,7 +148,6 @@ extension ResponderViewController: WalletConnectClientDelegate {
     func didSettle(session: SessionType.Settled) {
         print("[RESPONDER] WC: Did settle session")
         let settledSessions = client.getSettledSessions()
-        print("Settled sessions: \(settledSessions)")
         let activeSessions = settledSessions.map { session -> ActiveSessionItem in
             let app = session.peer.metadata
             return ActiveSessionItem(

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -200,7 +200,7 @@ final class PairingEngine {
             relay: approveParams.relay,
             sharedKey: agreementKeys.sharedSecret.toHexString(),
             self: PairingType.Participant(publicKey: selfPublicKey.toHexString()),
-            peer: PairingType.Participant(publicKey: approveParams.responder.publicKey),
+            peer: PairingType.Participant(publicKey: approveParams.responder.publicKey, metadata: approveParams.responder.metadata),
             permissions: PairingType.Permissions(
                 jsonrpc: proposal.permissions.jsonrpc,
                 controller: controller),

--- a/Sources/WalletConnect/Types/Pairing/PairingSettled.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSettled.swift
@@ -3,11 +3,11 @@ import Foundation
 
 extension PairingType {
     public struct Settled: Codable, SequenceSettled, Equatable {
-        let topic: String
+        public let topic: String
         let relay: RelayProtocolOptions
         let sharedKey: String
         let `self`: Participant
-        let peer: Participant
+        public let peer: Participant
         let permissions: Permissions
         let expiry: Int
         let state: State?

--- a/Sources/WalletConnect/Types/Pairing/PairingSuccessResponse.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSuccessResponse.swift
@@ -8,9 +8,9 @@ extension PairingType {
         let metadata: AppMetadata
     }
     
-    struct Participant:Codable, Equatable {
+    public struct Participant:Codable, Equatable {
         let publicKey: String
-        let metadata: AppMetadata?
+        public let metadata: AppMetadata?
         
         init(publicKey: String, metadata: AppMetadata? = nil) {
             self.publicKey = publicKey

--- a/Sources/WalletConnect/Types/Session/ClientSynchronisation/SessionDeleteParams.swift
+++ b/Sources/WalletConnect/Types/Session/ClientSynchronisation/SessionDeleteParams.swift
@@ -3,17 +3,22 @@ import Foundation
 
 extension SessionType {
     public struct DeleteParams: Codable, Equatable {
-        let topic: String
-        let reason: Reason
+        public let topic: String
+        public let reason: Reason
         
-        init(topic: String, reason: SessionType.Reason) {
+        public init(topic: String, reason: SessionType.Reason) {
             self.topic = topic
             self.reason = reason
         }
     }
     
     public struct Reason: Codable, Equatable {
-        let code: Int
-        let message: String
+        public let code: Int
+        public let message: String
+        
+        public init(code: Int, message: String) {
+            self.code = code
+            self.message = message
+        }
     }
 }

--- a/Sources/WalletConnect/Types/Session/SessionSettled.swift
+++ b/Sources/WalletConnect/Types/Session/SessionSettled.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension SessionType {
     public struct Settled: Codable, SequenceSettled, Equatable {
-        let topic: String
+        public let topic: String
         let relay: RelayProtocolOptions
         let sharedKey: String
         let `self`: Participant


### PR DESCRIPTION
closes #90 
closes #91 

Adds a list of settled pairings to the Dapp screen that is updated whenever a new pairing is settled.

Session rejection now calls reject on client and deleting a session cell send a disconnect call to the client.