### PR TITLE
#103 anycodable fix

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/WalletConnect.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/WalletConnect.xcscheme
@@ -40,7 +40,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WalletConnect"
+            BuildableName = "WalletConnect"
+            BlueprintName = "WalletConnect"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,7 +63,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "IntegrationTests"

--- a/Example/ExampleApp/Proposer/ProposerViewController.swift
+++ b/Example/ExampleApp/Proposer/ProposerViewController.swift
@@ -123,6 +123,10 @@ extension ProposerViewController: UITableViewDataSource, UITableViewDelegate {
 
 extension ProposerViewController: WalletConnectClientDelegate {
     
+    func didDelete(sessionTopic: String, reason: SessionType.Reason) {
+        
+    }
+    
     func didReceive(sessionProposal: SessionType.Proposal) {
         print("[PROPOSER] WC: Did receive session proposal")
     }

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -89,8 +89,8 @@ extension ResponderViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
             let item = sessionItems[indexPath.row]
-            let deleteParams = SessionType.DeleteParams(topic: item.topic, reason: SessionType.Reason(code: 0, message: "disconnect"))
-            client.disconnect(params: deleteParams)
+//            let deleteParams = SessionType.DeleteParams(topic: item.topic, reason: SessionType.Reason(code: 0, message: "disconnect"))
+            client.disconnect(topic: item.topic, reason: SessionType.Reason(code: 0, message: "disconnect"))
             sessionItems.remove(at: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .automatic)
         }
@@ -118,7 +118,7 @@ extension ResponderViewController: SessionViewControllerDelegate {
         print("[RESPONDER] Approving session...")
         let proposal = currentProposal!
         currentProposal = nil
-        client.approve(proposal: proposal)
+        client.approve(proposal: proposal, accounts: [])
     }
     
     func didRejectSession() {
@@ -130,6 +130,10 @@ extension ResponderViewController: SessionViewControllerDelegate {
 }
 
 extension ResponderViewController: WalletConnectClientDelegate {
+    
+    func didDelete(sessionTopic: String, reason: SessionType.Reason) {
+        
+    }
     
     func didReceive(sessionProposal: SessionType.Proposal) {
         print("[RESPONDER] WC: Did receive session proposal")

--- a/Sources/WalletConnect/Utils/Types/AnyCodable.swift
+++ b/Sources/WalletConnect/Utils/Types/AnyCodable.swift
@@ -1,41 +1,183 @@
 
 import Foundation
 
-public struct AnyCodable: Decodable, Equatable {
-    public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
-        fatalError("Not implemented")
-    }
+//protocol SuperCodableProtocol {
+//    associatedtype Value
+//}
+
+//struct SuperCodable: SuperCodableProtocol {
+//    let value: Value
+//}
+
+
+//public struct AnyCodable2: Codable {
+//
+//    let value: Any
+////    let metatype: Metatype
+//
+//    var encoderBlock: ((Encoder) throws -> Void)?
+//
+//    init<C>(_ codable: C) where C: Codable {
+////        let metatype = type(of: codable)
+//
+////        let data = try? JSONEncoder().encode(codable)
+//        value = codable
+//
+//        encoderBlock = { encoder in
+//            try codable.encode(to: encoder)
+//        }
+//    }
+//
+//    public init(from decoder: Decoder) throws {
+//        fatalError()
+//    }
+//
+//    public func encode(to encoder: Encoder) throws {
+//        try encoderBlock?(encoder)
+//    }
+//
+//
+//}
+
+
+public struct AnyCodable: Decodable, Encodable {
     
-    public var value: Any
+    public let value: Any
     
-    struct CodingKeys: CodingKey {
-        var stringValue: String
-        var intValue: Int?
-        init?(intValue: Int) {
-            self.stringValue = "\(intValue)"
-            self.intValue = intValue
-        }
-        init?(stringValue: String) { self.stringValue = stringValue }
-    }
+    var customEncoder: ((Encoder) throws -> Void)?
     
     public init(_ value: Any) {
         self.value = value
     }
     
+//    public init(enc: Codable) {
+//        self.value = enc
+//    }
+    
+    public init<C>(_ codable: C) where C: Codable {
+        self.value = codable
+        customEncoder = { encoder in
+            try codable.encode(to: encoder)
+        }
+    }
+    
+    public func get<T: Codable>(_ type: T.Type) -> T? {
+        if let data = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed]) {
+            
+            if let decoded = try? JSONDecoder().decode(type, from: data) {
+                return decoded
+            }
+        }
+        return nil
+    }
+}
+
+extension AnyCodable {
+    
+    struct CodingKeys: CodingKey {
+        
+        let stringValue: String
+        let intValue: Int?
+        
+        init?(intValue: Int) {
+            self.stringValue = String(intValue)
+            self.intValue = intValue
+        }
+        
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+            self.intValue = Int(stringValue)
+        }
+    }
+}
+
+extension AnyCodable {
+    
+    public func encode(to encoder: Encoder) throws {
+        if let encod = customEncoder {
+            try encod(encoder)
+            return
+        }
+//        throw WalletConnectError.pairingProposalGenerationFailed
+        
+        if let array = value as? [Any] {
+            
+            var container = encoder.unkeyedContainer()
+            
+            for value in array {
+                let decodable = AnyCodable(value)
+                try container.encode(decodable)
+            }
+        }
+        
+        else if let dictionary = value as? [String: Any] {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            for (key, value) in dictionary {
+                let codingKey = CodingKeys(stringValue: key)!
+                let decodable = AnyCodable(value)
+                try container.encode(decodable, forKey: codingKey)
+            }
+        }
+        
+//        else if let val = value as? Encodable {
+////            var container = encoder.unkeyedContainer()
+////            try container.encode(val)
+//            var container = encoder.container(keyedBy: CodingKeys.self)
+////            try container.encode(val)
+////            try container.encode(val, forKey: CodingKeys(stringValue: "key"))
+//        }
+        
+        else {
+            var container = encoder.singleValueContainer()
+            if let intVal = value as? Int {
+                try container.encode(intVal)
+            } else if let doubleVal = value as? Double {
+                try container.encode(doubleVal)
+            } else if let boolVal = value as? Bool {
+                try container.encode(boolVal)
+            } else if let stringVal = value as? String {
+                try container.encode(stringVal)
+            } else {
+                throw EncodingError.invalidValue(value, EncodingError.Context.init(codingPath: [], debugDescription: "The value is not encodable"))
+                
+//                let jsonData = try JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed])
+//                let jsonObj = try JSONSerialization.jsonObject(with: jsonData, options: [.fragmentsAllowed])
+//                if let cast = jsonObj as? [String: Any] {
+//                    var container = encoder.container(keyedBy: CodingKeys.self)
+//                    for (key, value) in cast {
+//                        let codingKey = CodingKeys(stringValue: key)!
+//                        let decodable = AnyCodable(value)
+//                        try container.encode(decodable, forKey: codingKey)
+//                    }
+//                }
+                
+            }
+        }
+    }
+}
+
+extension AnyCodable {
+    
     public init(from decoder: Decoder) throws {
+        
         if let container = try? decoder.container(keyedBy: CodingKeys.self) {
+            
             var result = [String: Any]()
             try container.allKeys.forEach { (key) throws in
                 result[key.stringValue] = try container.decode(AnyCodable.self, forKey: key).value
             }
             value = result
-        } else if var container = try? decoder.unkeyedContainer() {
+        }
+        
+        else if var container = try? decoder.unkeyedContainer() {
             var result = [Any]()
             while !container.isAtEnd {
                 result.append(try container.decode(AnyCodable.self).value)
             }
             value = result
-        } else if let container = try? decoder.singleValueContainer() {
+        }
+        
+        else if let container = try? decoder.singleValueContainer() {
             if let intVal = try? container.decode(Int.self) {
                 value = intVal
             } else if let doubleVal = try? container.decode(Double.self) {
@@ -53,35 +195,10 @@ public struct AnyCodable: Decodable, Equatable {
     }
 }
 
-extension AnyCodable: Encodable {
-    public func encode(to encoder: Encoder) throws {
-        if let array = value as? [Any] {
-            var container = encoder.unkeyedContainer()
-            for value in array {
-                let decodable = AnyCodable(value)
-                try container.encode(decodable)
-            }
-        } else if let dictionary = value as? [String: Any] {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            for (key, value) in dictionary {
-                let codingKey = CodingKeys(stringValue: key)!
-                let decodable = AnyCodable(value)
-                try container.encode(decodable, forKey: codingKey)
-            }
-        } else {
-            var container = encoder.singleValueContainer()
-            if let intVal = value as? Int {
-                try container.encode(intVal)
-            } else if let doubleVal = value as? Double {
-                try container.encode(doubleVal)
-            } else if let boolVal = value as? Bool {
-                try container.encode(boolVal)
-            } else if let stringVal = value as? String {
-                try container.encode(stringVal)
-            } else {
-                throw EncodingError.invalidValue(value, EncodingError.Context.init(codingPath: [], debugDescription: "The value is not encodable"))
-            }
-            
-        }
+
+
+extension AnyCodable: Equatable {
+    public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+        fatalError("Not implemented")
     }
 }

--- a/Sources/WalletConnect/Utils/Types/AnyCodable.swift
+++ b/Sources/WalletConnect/Utils/Types/AnyCodable.swift
@@ -1,44 +1,4 @@
-
 import Foundation
-
-//protocol SuperCodableProtocol {
-//    associatedtype Value
-//}
-
-//struct SuperCodable: SuperCodableProtocol {
-//    let value: Value
-//}
-
-
-//public struct AnyCodable2: Codable {
-//
-//    let value: Any
-////    let metatype: Metatype
-//
-//    var encoderBlock: ((Encoder) throws -> Void)?
-//
-//    init<C>(_ codable: C) where C: Codable {
-////        let metatype = type(of: codable)
-//
-////        let data = try? JSONEncoder().encode(codable)
-//        value = codable
-//
-//        encoderBlock = { encoder in
-//            try codable.encode(to: encoder)
-//        }
-//    }
-//
-//    public init(from decoder: Decoder) throws {
-//        fatalError()
-//    }
-//
-//    public func encode(to encoder: Encoder) throws {
-//        try encoderBlock?(encoder)
-//    }
-//
-//
-//}
-
 
 public struct AnyCodable: Decodable, Encodable {
     
@@ -49,11 +9,7 @@ public struct AnyCodable: Decodable, Encodable {
     public init(_ value: Any) {
         self.value = value
     }
-    
-//    public init(enc: Codable) {
-//        self.value = enc
-//    }
-    
+
     public init<C>(_ codable: C) where C: Codable {
         self.value = codable
         customEncoder = { encoder in
@@ -139,18 +95,6 @@ extension AnyCodable {
                 try container.encode(stringVal)
             } else {
                 throw EncodingError.invalidValue(value, EncodingError.Context.init(codingPath: [], debugDescription: "The value is not encodable"))
-                
-//                let jsonData = try JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed])
-//                let jsonObj = try JSONSerialization.jsonObject(with: jsonData, options: [.fragmentsAllowed])
-//                if let cast = jsonObj as? [String: Any] {
-//                    var container = encoder.container(keyedBy: CodingKeys.self)
-//                    for (key, value) in cast {
-//                        let codingKey = CodingKeys(stringValue: key)!
-//                        let decodable = AnyCodable(value)
-//                        try container.encode(decodable, forKey: codingKey)
-//                    }
-//                }
-                
             }
         }
     }

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -121,7 +121,7 @@ final class ClientTests: XCTestCase {
         let uri = try! proposer.client.connect(params: connectParams)!
         _ = try! responder.client.pair(uri: uri)
         responder.onSessionProposal = { proposal in
-            responder.client.approve(proposal: proposal)
+            responder.client.approve(proposal: proposal, accounts: [])
         }
         proposer.onSessionSettled = { settledSession in
             proposer.client.disconnect(topic: settledSession.topic, reason: SessionType.Reason(code: 5900, message: "User disconnected session"))

--- a/Tests/WalletConnectTests/AnyCodableTests.swift
+++ b/Tests/WalletConnectTests/AnyCodableTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+@testable import WalletConnect
+
+class AnyCodableTests: XCTestCase {
+
+    func testCodingBool() {
+        [true, false].forEach { bool in
+            do {
+                let anyCodable = AnyCodable(bool)
+                let encoded = try JSONEncoder().encode(anyCodable)
+                let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+                let codingResult = decoded.value as? Bool
+                XCTAssertEqual(bool, codingResult)
+            } catch {
+                XCTFail()
+            }
+        }
+    }
+    
+    func testCodingStruct() {
+        do {
+            let aaa = EthTransaction.make("0xbeef")
+            let value = AnyCodable(aaa)
+            let encoded = try JSONEncoder().encode(value)
+            let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+            let obj = decoded.get(EthTransaction.self)
+            XCTAssertEqual(aaa, obj)
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testMore() {
+        let dict: [String: String] = [
+            "from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+            "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
+            "data":
+              "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+            "gasLimit": "0x76c0",
+            "gasPrice": "0x9184e72a000",
+            "value": "0x9184e72a",
+            "nonce": "0x117"
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: dict, options: [.fragmentsAllowed])
+        
+        let string1 = """
+{
+    "from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+    "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
+    "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+    "gasLimit": "0x76c0",
+    "gasPrice": "0x9184e72a000",
+    "value": "0x9184e72a",
+    "nonce": "0x117"
+}
+"""
+//        let data = string1.data(using: .utf8)!
+        let decoded = try! JSONDecoder().decode(AnyCodable.self, from: data)
+        let encoded = try! JSONEncoder().encode(decoded)
+        let model = try? JSONDecoder().decode(EthTransaction.self, from: encoded)
+        let dict2 = try? JSONSerialization.jsonObject(with: encoded, options: [.allowFragments]) as? [String: String]
+        XCTAssertEqual(dict, dict2)
+        XCTAssertNotNil(model)
+        print()
+        print("Strings:")
+        print()
+        print(string1)
+        print()
+//        print(str)
+        print()
+    }
+    
+    func testDecodingStruct() {
+        let data = """
+{
+    "from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+    "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
+    "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+    "gas": "0x76c0",
+    "gasPrice": "0x9184e72a000",
+    "value": "0x9184e72a",
+    "nonce": "0x117"
+}
+""".data(using: .utf8)!
+        
+        let decoded = try! JSONDecoder().decode(AnyCodable.self, from: data)
+        print()
+        print("\(decoded.value)")
+        print()
+//        XCTAssertNotNil(decoded)
+        let castDict = decoded.value as? [String: Any]
+        print("Cast to dictionary: \(castDict)")
+        print()
+        let castStruct = decoded.value as? EthTransaction
+        print("Cast to struct: \(castStruct)")
+        print()
+    }
+    
+    func testCodingStructArray() {
+        do {
+            let e1 = EthTransaction.make("0x1234")
+            let e2 = EthTransaction.make("0x9876")
+            let array = [e1, e2]
+            let value = AnyCodable(array)
+            let encoded = try JSONEncoder().encode(value)
+            let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+            let cast = decoded.get([EthTransaction].self)
+            XCTAssertNotNil(cast)
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testDecodeBool() {
+//        let data = """
+//{
+//    true
+//}
+//""".data(using: .utf8)!
+        let data = "true".data(using: .utf8)!
+        let decoded = try? JSONDecoder().decode(AnyCodable.self, from: data)
+        XCTAssertNotNil(decoded)
+        let cast = decoded?.value as? Bool
+        XCTAssertNotNil(cast)
+    }
+    
+    func testEncodeInt() {
+        let codable = AnyCodable(1337)
+        let encoded = try? JSONEncoder().encode(codable)
+        XCTAssertNotNil(encoded)
+    }
+    
+    func testEncodeDouble() {
+        let codable = AnyCodable(13.37)
+        let encoded = try? JSONEncoder().encode(codable)
+        XCTAssertNotNil(encoded)
+    }
+    
+    func testEncodeString() {
+        let codable = AnyCodable("aString")
+        let encoded = try? JSONEncoder().encode(codable)
+        XCTAssertNotNil(encoded)
+    }
+    
+    func testEncodeArray() {
+        let codable = AnyCodable([1,1,1])
+        let encoded = try? JSONEncoder().encode(codable)
+        XCTAssertNotNil(encoded)
+    }
+    
+//    func testEncodeStruct() {
+//        let obj = TestStruct(test: 93)
+//        let codable = AnyCodable(obj)
+//        let encoded = try? JSONEncoder().encode(codable)
+//        XCTAssertNotNil(encoded)
+//    }
+}
+
+struct TestStruct: Codable, Equatable {
+    let int: Int
+}
+
+public struct EthTransaction: Codable, Equatable {
+    public let from: String
+    public let data: String
+    public let gasLimit: String
+    public let value: String
+    public let to: String
+    public let gasPrice: String
+    public let nonce: String
+    
+    static func make(_ nonce: String = "0x00") -> EthTransaction {
+        EthTransaction(
+            from: "0xdeadbeef", data: "some data",
+            gasLimit: "0.001", value: "1.001",
+            to: "0x02394854", gasPrice: "0.3", nonce: nonce)
+    }
+}

--- a/Tests/WalletConnectTests/AnyCodableTests.swift
+++ b/Tests/WalletConnectTests/AnyCodableTests.swift
@@ -1,6 +1,28 @@
 import XCTest
 @testable import WalletConnect
 
+struct CodableStub: Codable, Equatable {
+    let bool: Bool
+    let int: Int
+    let double: Double
+    let string: String
+    let object: Obje
+    
+    struct Obje: Codable, Equatable {
+        let string: String
+    }
+    
+    static func stub() -> CodableStub {
+        CodableStub(
+            bool: Bool.random(),
+            int: Int.random(in: Int.min...Int.max),
+            double: Double.random(in: -1337.00...1337.00),
+            string: UUID().uuidString,
+            object: Obje(string: UUID().uuidString)
+        )
+    }
+}
+
 class AnyCodableTests: XCTestCase {
 
     func testCodingBool() {
@@ -9,7 +31,7 @@ class AnyCodableTests: XCTestCase {
                 let anyCodable = AnyCodable(bool)
                 let encoded = try JSONEncoder().encode(anyCodable)
                 let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
-                let codingResult = decoded.value as? Bool
+                let codingResult = decoded.get(Bool.self)
                 XCTAssertEqual(bool, codingResult)
             } catch {
                 XCTFail()
@@ -17,162 +39,81 @@ class AnyCodableTests: XCTestCase {
         }
     }
     
-    func testCodingStruct() {
+    func testCodingInt() {
         do {
-            let aaa = EthTransaction.make("0xbeef")
-            let value = AnyCodable(aaa)
-            let encoded = try JSONEncoder().encode(value)
+            let int = Int.random(in: Int.min...Int.max)
+            let anyCodable = AnyCodable(int)
+            let encoded = try JSONEncoder().encode(anyCodable)
             let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
-            let obj = decoded.get(EthTransaction.self)
-            XCTAssertEqual(aaa, obj)
+            let codingResult = decoded.get(Int.self)
+            XCTAssertEqual(int, codingResult)
         } catch {
             XCTFail()
         }
     }
     
-    func testMore() {
-        let dict: [String: String] = [
-            "from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
-            "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
-            "data":
-              "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
-            "gasLimit": "0x76c0",
-            "gasPrice": "0x9184e72a000",
-            "value": "0x9184e72a",
-            "nonce": "0x117"
-        ]
-        let data = try! JSONSerialization.data(withJSONObject: dict, options: [.fragmentsAllowed])
-        
-        let string1 = """
-{
-    "from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
-    "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
-    "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
-    "gasLimit": "0x76c0",
-    "gasPrice": "0x9184e72a000",
-    "value": "0x9184e72a",
-    "nonce": "0x117"
-}
-"""
-//        let data = string1.data(using: .utf8)!
-        let decoded = try! JSONDecoder().decode(AnyCodable.self, from: data)
-        let encoded = try! JSONEncoder().encode(decoded)
-        let model = try? JSONDecoder().decode(EthTransaction.self, from: encoded)
-        let dict2 = try? JSONSerialization.jsonObject(with: encoded, options: [.allowFragments]) as? [String: String]
-        XCTAssertEqual(dict, dict2)
-        XCTAssertNotNil(model)
-        print()
-        print("Strings:")
-        print()
-        print(string1)
-        print()
-//        print(str)
-        print()
+    func testCodingDouble() {
+        do {
+            let double = Double.random(in: -1337.00...1337.00)
+            let anyCodable = AnyCodable(double)
+            let encoded = try JSONEncoder().encode(anyCodable)
+            let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+            let codingResult = decoded.get(Double.self)
+            XCTAssertEqual(double, codingResult)
+        } catch {
+            XCTFail()
+        }
     }
     
-    func testDecodingStruct() {
-        let data = """
-{
-    "from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
-    "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
-    "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
-    "gas": "0x76c0",
-    "gasPrice": "0x9184e72a000",
-    "value": "0x9184e72a",
-    "nonce": "0x117"
-}
-""".data(using: .utf8)!
-        
-        let decoded = try! JSONDecoder().decode(AnyCodable.self, from: data)
-        print()
-        print("\(decoded.value)")
-        print()
-//        XCTAssertNotNil(decoded)
-        let castDict = decoded.value as? [String: Any]
-        print("Cast to dictionary: \(castDict)")
-        print()
-        let castStruct = decoded.value as? EthTransaction
-        print("Cast to struct: \(castStruct)")
-        print()
+    func testCodingString() {
+        do {
+            let string = UUID().uuidString
+            let anyCodable = AnyCodable(string)
+            let encoded = try JSONEncoder().encode(anyCodable)
+            let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+            let codingResult = decoded.get(String.self)
+            XCTAssertEqual(string, codingResult)
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testCodingArray() {
+        do {
+            let array = (1...10).map { _ in UUID().uuidString }
+            let anyCodable = AnyCodable(array)
+            let encoded = try JSONEncoder().encode(anyCodable)
+            let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+            let codingResult = decoded.get([String].self)
+            XCTAssertEqual(array, codingResult)
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testCodingStruct() {
+        do {
+            let object = CodableStub.stub()
+            let value = AnyCodable(object)
+            let encoded = try JSONEncoder().encode(value)
+            let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
+            let codingResult = decoded.get(CodableStub.self)
+            XCTAssertEqual(object, codingResult)
+        } catch {
+            XCTFail()
+        }
     }
     
     func testCodingStructArray() {
         do {
-            let e1 = EthTransaction.make("0x1234")
-            let e2 = EthTransaction.make("0x9876")
-            let array = [e1, e2]
-            let value = AnyCodable(array)
+            let objects = (1...10).map { _ in CodableStub.stub() }
+            let value = AnyCodable(objects)
             let encoded = try JSONEncoder().encode(value)
             let decoded = try JSONDecoder().decode(AnyCodable.self, from: encoded)
-            let cast = decoded.get([EthTransaction].self)
-            XCTAssertNotNil(cast)
+            let codingResult = decoded.get([CodableStub].self)
+            XCTAssertEqual(objects, codingResult)
         } catch {
             XCTFail()
         }
-    }
-    
-    func testDecodeBool() {
-//        let data = """
-//{
-//    true
-//}
-//""".data(using: .utf8)!
-        let data = "true".data(using: .utf8)!
-        let decoded = try? JSONDecoder().decode(AnyCodable.self, from: data)
-        XCTAssertNotNil(decoded)
-        let cast = decoded?.value as? Bool
-        XCTAssertNotNil(cast)
-    }
-    
-    func testEncodeInt() {
-        let codable = AnyCodable(1337)
-        let encoded = try? JSONEncoder().encode(codable)
-        XCTAssertNotNil(encoded)
-    }
-    
-    func testEncodeDouble() {
-        let codable = AnyCodable(13.37)
-        let encoded = try? JSONEncoder().encode(codable)
-        XCTAssertNotNil(encoded)
-    }
-    
-    func testEncodeString() {
-        let codable = AnyCodable("aString")
-        let encoded = try? JSONEncoder().encode(codable)
-        XCTAssertNotNil(encoded)
-    }
-    
-    func testEncodeArray() {
-        let codable = AnyCodable([1,1,1])
-        let encoded = try? JSONEncoder().encode(codable)
-        XCTAssertNotNil(encoded)
-    }
-    
-//    func testEncodeStruct() {
-//        let obj = TestStruct(test: 93)
-//        let codable = AnyCodable(obj)
-//        let encoded = try? JSONEncoder().encode(codable)
-//        XCTAssertNotNil(encoded)
-//    }
-}
-
-struct TestStruct: Codable, Equatable {
-    let int: Int
-}
-
-public struct EthTransaction: Codable, Equatable {
-    public let from: String
-    public let data: String
-    public let gasLimit: String
-    public let value: String
-    public let to: String
-    public let gasPrice: String
-    public let nonce: String
-    
-    static func make(_ nonce: String = "0x00") -> EthTransaction {
-        EthTransaction(
-            from: "0xdeadbeef", data: "some data",
-            gasLimit: "0.001", value: "1.001",
-            to: "0x02394854", gasPrice: "0.3", nonce: nonce)
     }
 }

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+BIN_PATH="$(swift build --show-bin-path)"
+XCTEST_PATH="$(find ${BIN_PATH} -name '*.xctest')"
+
+COV_BIN=$XCTEST_PATH
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    f="$(basename $XCTEST_PATH .xctest)"
+    COV_BIN="${COV_BIN}/Contents/MacOS/$f"
+fi
+
+swift package clean
+swift test --enable-code-coverage
+
+llvm-cov report \
+    "${COV_BIN}" \
+    -instr-profile=.build/debug/codecov/default.profdata \
+    -ignore-filename-regex=".build|Tests" \
+    -use-color


### PR DESCRIPTION
closes #103 
closes #99 

Refactor on AnyCodable type to allow for user-created structs encoding by preserving type information through a generic init capture. Adds `get` method to lazy-decode the underlying type and cast into any decodable object. Many shenanigans.

Also adds a `coverage.sh` script to the project folder. To run it, LLVM needs to be installed (`brew install llvm`).
The script makes a clean build before running all tests and report coverage from the artifacts generated.