### PR TITLE
#96 implement ping request

### DIFF
--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -142,6 +142,10 @@ final class SessionEngine {
     }
     
     func ping(topic: String, completion: @escaping ((Result<Void, Error>) -> ())) {
+        guard let _ = sequencesStore.get(topic: topic) else {
+            logger.debug("Could not find session to ping for topic \(topic)")
+            return
+        }
         let request = ClientSynchJSONRPC(method: .sessionPing, params: .sessionPing(SessionType.PingParams()))
         relayer.request(topic: topic, payload: request) { [unowned self] result in
             switch result {

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -201,22 +201,33 @@ final class SessionEngine {
     
     private func setUpWCRequestHandling() {
         wcSubscriber.onRequestSubscription = { [unowned self] subscriptionPayload in
+            let requestId = subscriptionPayload.clientSynchJsonRpc.id
+            let topic = subscriptionPayload.topic
             switch subscriptionPayload.clientSynchJsonRpc.params {
             case .sessionApprove(let approveParams):
-                self.handleSessionApprove(approveParams, topic: subscriptionPayload.topic, requestId: subscriptionPayload.clientSynchJsonRpc.id)
+                self.handleSessionApprove(approveParams, topic: topic, requestId: requestId)
             case .sessionReject(let rejectParams):
-                handleSessionReject(rejectParams, topic: subscriptionPayload.topic)
+                handleSessionReject(rejectParams, topic: topic)
             case .sessionUpdate(_):
                 fatalError("Not implemented")
             case .sessionUpgrade(_):
                 fatalError("Not implemented")
             case .sessionDelete(let deleteParams):
-                handleSessionDelete(deleteParams, topic: subscriptionPayload.topic)
+                handleSessionDelete(deleteParams, topic: topic)
             case .sessionPayload(let sessionPayloadParams):
-                self.handleSessionPayload(payloadParams: sessionPayloadParams, topic: subscriptionPayload.topic, requestId: subscriptionPayload.clientSynchJsonRpc.id)
+                self.handleSessionPayload(payloadParams: sessionPayloadParams, topic: topic, requestId: requestId)
+            case .sessionPing(_):
+                self.handleSessionPing(topic: topic, requestId: requestId)
             default:
                 fatalError("unexpected method type")
             }
+        }
+    }
+    
+    private func handleSessionPing(topic: String, requestId: Int64) {
+        let response = JSONRPCResponse<Bool>(id: requestId, result: true)
+        relayer.respond(topic: topic, payload: response) { error in
+            //todo
         }
     }
     

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -141,6 +141,19 @@ final class SessionEngine {
         }
     }
     
+    func ping(topic: String, completion: @escaping ((Result<Void, Error>) -> ())) {
+        let request = ClientSynchJSONRPC(method: .sessionPing, params: .sessionPing(SessionType.PingParams()))
+        relayer.request(topic: topic, payload: request) { [unowned self] result in
+            switch result {
+            case .success(_):
+                logger.debug("Did receive ping response")
+                completion(.success(()))
+            case .failure(let error):
+                logger.debug("error: \(error)")
+            }
+        }
+    }
+    
     func request(params: SessionType.PayloadRequestParams, completion: @escaping ((Result<JSONRPCResponse<AnyCodable>, Error>)->())) {
         guard let _ = sequencesStore.get(topic: params.topic) else {
             logger.debug("Could not find session for topic \(params.topic)")

--- a/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC.swift
+++ b/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC.swift
@@ -45,6 +45,9 @@ struct ClientSynchJSONRPC: Codable {
         case .pairingPayload:
             let paramsValue = try container.decode(PairingType.PayloadParams.self, forKey: .params)
             params = .pairingPayload(paramsValue)
+        case .pairingPing:
+            let paramsValue = try container.decode(PairingType.PingParams.self, forKey: .params)
+            params = .pairingPing(paramsValue)
         case .sessionPropose:
             let paramsValue = try container.decode(SessionType.ProposeParams.self, forKey: .params)
             params = .sessionPropose(paramsValue)
@@ -89,6 +92,8 @@ struct ClientSynchJSONRPC: Codable {
         case .pairingDelete(let params):
             try container.encode(params, forKey: .params)
         case .pairingPayload(let params):
+            try container.encode(params, forKey: .params)
+        case .pairingPing(let params):
             try container.encode(params, forKey: .params)
         case .sessionPropose(let params):
             try container.encode(params, forKey: .params)

--- a/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC.swift
+++ b/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC.swift
@@ -66,6 +66,9 @@ struct ClientSynchJSONRPC: Codable {
         case .sessionPayload:
             let paramsValue = try container.decode(SessionType.PayloadParams.self, forKey: .params)
             params = .sessionPayload(paramsValue)
+        case .sessionPing:
+            let paramsValue = try container.decode(SessionType.PingParams.self, forKey: .params)
+            params = .sessionPing(paramsValue)
         }
     }
     
@@ -100,6 +103,8 @@ struct ClientSynchJSONRPC: Codable {
         case .sessionDelete(let params):
             try container.encode(params, forKey: .params)
         case .sessionPayload(let params):
+            try container.encode(params, forKey: .params)
+        case .sessionPing(let params):
             try container.encode(params, forKey: .params)
         }
     }

--- a/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC_Method.swift
+++ b/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC_Method.swift
@@ -9,6 +9,7 @@ extension ClientSynchJSONRPC {
         case pairingUpgrade = "wc_pairingUpgrade"
         case pairingDelete = "wc_pairingDelete"
         case pairingPayload = "wc_pairingPayload"
+        case pairingPing = "wc_pairingPing"
         case sessionPropose = "wc_sessionPropose"
         case sessionApprove = "wc_sessionApprove"
         case sessionReject = "wc_sessionReject"

--- a/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC_Method.swift
+++ b/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC_Method.swift
@@ -16,5 +16,6 @@ extension ClientSynchJSONRPC {
         case sessionUpgrade = "wc_sessionUpgrade"
         case sessionDelete = "wc_sessionDelete"
         case sessionPayload = "wc_sessionPayload"
+        case sessionPing = "wc_sessionPing"
     }
 }

--- a/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC_Params.swift
+++ b/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC_Params.swift
@@ -9,6 +9,7 @@ extension ClientSynchJSONRPC {
         case pairingUpgrade(PairingType.UpgradeParams)
         case pairingDelete(PairingType.DeleteParams)
         case pairingPayload(PairingType.PayloadParams)
+        case pairingPing(PairingType.PingParams)
         // sessionPropose method exists exclusively within a pairing payload
         case sessionPropose(SessionType.ProposeParams)
         case sessionApprove(SessionType.ApproveParams)

--- a/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC_Params.swift
+++ b/Sources/WalletConnect/Types/ClientSynchJSONRPC/ClientSynchJSONRPC_Params.swift
@@ -17,6 +17,7 @@ extension ClientSynchJSONRPC {
         case sessionUpgrade(SessionType.UpgradeParams)
         case sessionDelete(SessionType.DeleteParams)
         case sessionPayload(SessionType.PayloadParams)
+        case sessionPing(SessionType.PingParams)
 
         static func == (lhs: Params, rhs: Params) -> Bool {
             switch (lhs, rhs) {
@@ -45,6 +46,8 @@ extension ClientSynchJSONRPC {
             case (.sessionDelete(let lhsParam), sessionDelete(let rhsParam)):
                 return lhsParam == rhsParam
             case (.sessionPayload(let lhsParam), sessionPayload(let rhsParam)):
+                return lhsParam == rhsParam
+            case (.sessionPing(let lhsParam), sessionPing(let rhsParam)):
                 return lhsParam == rhsParam
             default:
                 return false

--- a/Sources/WalletConnect/Types/Pairing/ClientSynchronisation/PairingPingParams.swift
+++ b/Sources/WalletConnect/Types/Pairing/ClientSynchronisation/PairingPingParams.swift
@@ -1,0 +1,7 @@
+
+
+import Foundation
+
+extension PairingType {
+    public struct PingParams: Codable, Equatable {}
+}

--- a/Sources/WalletConnect/Types/Session/ClientSynchronisation/SessionPingParams.swift
+++ b/Sources/WalletConnect/Types/Session/ClientSynchronisation/SessionPingParams.swift
@@ -1,0 +1,6 @@
+
+import Foundation
+
+extension SessionType {
+    public struct PingParams: Codable, Equatable {}
+}

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -111,6 +111,9 @@ public final class WalletConnectClient {
     }
     
     public func ping(topic: String, completion: @escaping ((Result<Void, Error>) -> ())) {
+        pairingEngine.ping(topic: topic) { result in
+            completion(result)
+        }
         sessionEngine.ping(topic: topic) { result in
             completion(result)
         }

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -110,7 +110,13 @@ public final class WalletConnectClient {
         sessionEngine.respondSessionPayload(topic: topic, response: response)
     }
     
-    // TODO: Ping and notification methods
+    public func ping(topic: String, completion: @escaping ((Result<Void, Error>) -> ())) {
+        sessionEngine.ping(topic: topic) { result in
+            completion(result)
+        }
+    }
+    
+    // TODO: notification method
     
     // for either to disconnect a session
     public func disconnect(topic: String, reason: SessionType.Reason) {
@@ -156,7 +162,6 @@ public final class WalletConnectClient {
         }
         sessionEngine.onSessionDelete = { [unowned self] topic, reason in
             self.delegate?.didDelete(sessionTopic: topic, reason: reason)
-            
         }
     }
     

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -111,11 +111,14 @@ public final class WalletConnectClient {
     }
     
     public func ping(topic: String, completion: @escaping ((Result<Void, Error>) -> ())) {
-        pairingEngine.ping(topic: topic) { result in
-            completion(result)
-        }
-        sessionEngine.ping(topic: topic) { result in
-            completion(result)
+        if pairingEngine.sequencesStore.get(topic: topic) != nil {
+            pairingEngine.ping(topic: topic) { result in
+                completion(result)
+            }
+        } else if sessionEngine.sequencesStore.get(topic: topic) != nil {
+            sessionEngine.ping(topic: topic) { result in
+                completion(result)
+            }
         }
     }
     

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import WalletConnect
 
 final class ClientTests: XCTestCase {
-    let url = URL(string: "wss://relay.walletconnect.com")! // TODO: Change to new URL
+    let url = URL(string: "wss://staging.walletconnect.org")! // TODO: Change to new URL
     var proposer: ClientDelegate!
     var responder: ClientDelegate!
     override func setUp() {

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -30,7 +30,6 @@ final class ClientTests: XCTestCase {
         let responderSettlesPairingExpectation = expectation(description: "Responder settles pairing")
         let permissions = SessionType.Permissions(blockchain: SessionType.Blockchain(chains: []), jsonrpc: SessionType.JSONRPC(methods: []))
         let connectParams = ConnectParams(permissions: permissions)
-        Thread.sleep(forTimeInterval: 0.3)
         let uri = try! proposer.client.connect(params: connectParams)!
         
         _ = try! responder.client.pair(uri: uri)
@@ -137,6 +136,22 @@ final class ClientTests: XCTestCase {
             requestExpectation.fulfill()
         }
         waitForExpectations(timeout: 4.0, handler: nil)
+    }
+    
+    func testPairingPing() {
+        let proposerReceivesPingResponseExpectation = expectation(description: "Proposer receives ping response")
+        let permissions = SessionType.Permissions(blockchain: SessionType.Blockchain(chains: []), jsonrpc: SessionType.JSONRPC(methods: []))
+        let connectParams = ConnectParams(permissions: permissions)
+        let uri = try! proposer.client.connect(params: connectParams)!
+        
+        _ = try! responder.client.pair(uri: uri)
+        proposer.onPairingSettled = { [unowned self] pairing in
+            proposer.client.ping(topic: pairing.topic) { response in
+                XCTAssertTrue(response.isSuccess)
+                proposerReceivesPingResponseExpectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 3.0, handler: nil)
     }
     
     


### PR DESCRIPTION
Provides ping requests for session and pairing as well as automatic responding for ping requests for both sequence types. Does not include timeout and retry for unsuccessful responses.
close #96 
