### PR TITLE
Either type

### DIFF
--- a/Sources/WalletConnect/Utils/Types/Either.swift
+++ b/Sources/WalletConnect/Utils/Types/Either.swift
@@ -1,0 +1,63 @@
+enum Either<Left, Right> {
+    case left(Left)
+    case right(Right)
+}
+
+extension Either {
+
+    init(_ left: Left) {
+        self = .left(left)
+    }
+
+    init(_ right: Right) {
+        self = .right(right)
+    }
+
+    var left: Left? {
+        guard case let .left(left) = self else { return nil }
+        return left
+    }
+
+    var right: Right? {
+        guard case let .right(right) = self else { return nil }
+        return right
+    }
+}
+
+extension Either: Equatable where Left: Equatable, Right: Equatable {
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case let (.left(lhs), .left(rhs)):
+            return lhs == rhs
+        case let (.right(lhs), .right(rhs)):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+extension Either: Codable where Left: Codable, Right: Codable {
+
+    init(from decoder: Decoder) throws {
+        if let left = try? Left(from: decoder) {
+            self.init(left)
+        } else if let right = try? Right(from: decoder) {
+            self.init(right)
+        } else {
+            let errorDescription = "Data couldn't be decoded into either of the underlying types."
+            let errorContext = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: errorDescription)
+            throw DecodingError.typeMismatch(Self.self, errorContext)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        switch self {
+        case let .left(left):
+            try left.encode(to: encoder)
+        case let .right(right):
+            try right.encode(to: encoder)
+        }
+    }
+}

--- a/Tests/WalletConnectTests/EitherTests.swift
+++ b/Tests/WalletConnectTests/EitherTests.swift
@@ -1,8 +1,46 @@
-//
-//  File.swift
-//  
-//
-//  Created by André Vants on 10/11/21.
-//
+import XCTest
+@testable import WalletConnect
 
-import Foundation
+final class EitherTests: XCTestCase {
+    
+    func testLeftValue() {
+        let value = "string"
+        let either = Either<String, Int>(value)
+        XCTAssertEqual(either.left, value)
+        XCTAssertNil(either.right)
+    }
+    
+    func testRightValue() {
+        let value = 1
+        let either = Either<String, Int>(value)
+        XCTAssertEqual(either.right, value)
+        XCTAssertNil(either.left)
+    }
+    
+    func testEquality() {
+        XCTAssert(Either<Int, Int>.left(1) == Either<Int, Int>.left(1))
+        XCTAssert(Either<Int, Int>.right(1) == Either<Int, Int>.right(1))
+        XCTAssert(Either<Int, Int>.left(1) != Either<Int, Int>.right(1))
+        XCTAssert(Either<Int, Int>.right(1) != Either<Int, Int>.left(1))
+    }
+    
+    func testCodableRoundTripLeft() throws {
+        let either = Either<String, Int>("string")
+        let encoded = try JSONEncoder().encode(either)
+        let decoded = try JSONDecoder().decode(Either<String, Int>.self, from: encoded)
+        XCTAssertEqual(decoded, either)
+    }
+    
+    func testCodableRoundTripRight() throws {
+        let either = Either<String, Int>(1)
+        let encoded = try JSONEncoder().encode(either)
+        let decoded = try JSONDecoder().decode(Either<String, Int>.self, from: encoded)
+        XCTAssertEqual(decoded, either)
+    }
+    
+    func testDecodingFail() throws {
+        let either = Either<Int, Int>.left(1)
+        let encoded = try JSONEncoder().encode(either)
+        XCTAssertThrowsError(try JSONDecoder().decode(Either<String, String>.self, from: encoded))
+    }
+}

--- a/Tests/WalletConnectTests/EitherTests.swift
+++ b/Tests/WalletConnectTests/EitherTests.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by André Vants on 10/11/21.
+//
+
+import Foundation


### PR DESCRIPTION
Adds `Either` utility type for mutually exclusive values. Can be used to differentiate pending and settled sequences with underlying values.