### PR TITLE
#124 expirable pairings

### DIFF
--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -33,6 +33,12 @@ final class PairingEngine {
         restoreSubscriptions()
     }
     
+    func getSettledPairings() -> [Pairing] {
+        sequencesStore.getAll()
+            .filter { $0.isSettled }
+            .map { Pairing(topic: $0.topic, peer: $0.settled?.state?.metadata) }
+    }
+    
     func approve(_ proposal: PairingType.Proposal, completion: @escaping (Result<Pairing, Error>) -> Void) {
         let privateKey = Crypto.X25519.generatePrivateKey()
         let selfPublicKey = privateKey.publicKey.toHexString()

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -46,7 +46,7 @@ final class PairingEngine {
         let pending = PairingSequence.Pending(
             proposal: proposal,
             status: .responded)
-        var pairingSequence = PairingSequence(
+        let pairingSequence = PairingSequence(
             topic: proposal.topic,
             relay: proposal.relay,
             selfParticipant: PairingType.Participant(publicKey: selfPublicKey),

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -6,9 +6,10 @@ final class PairingEngine {
     private let relayer: WalletConnectRelaying
     private let crypto: Crypto
     private var isController: Bool
-    var sequencesStore: PairingSequencesStore
+    var sequencesStore: SequenceStore<PairingSequence>
     var onSessionProposal: ((SessionType.Proposal)->())?
-    var onPairingApproved: ((PairingType.Settled, String)->())?
+//    var onPairingApproved: ((PairingType.Settled, String)->())?
+    var onPairingApproved: ((Pairing, String, RelayProtocolOptions)->())?
     var onPairingUpdate: ((String, AppMetadata)->())?
     private var appMetadata: AppMetadata
     private var publishers = [AnyCancellable]()
@@ -17,7 +18,7 @@ final class PairingEngine {
     init(relay: WalletConnectRelaying,
          crypto: Crypto,
          subscriber: WCSubscribing,
-         sequencesStore: PairingSequencesStore,
+         sequencesStore: SequenceStore<PairingSequence>,
          isController: Bool,
          metadata: AppMetadata,
          logger: BaseLogger) {
@@ -32,19 +33,33 @@ final class PairingEngine {
         restoreSubscriptions()
     }
     
-    func approve(_ proposal: PairingType.Proposal, completion: @escaping (Result<PairingType.Settled, Error>) -> Void) {
+    func approve(_ proposal: PairingType.Proposal, completion: @escaping (Result<Pairing, Error>) -> Void) {
         let privateKey = Crypto.X25519.generatePrivateKey()
         let selfPublicKey = privateKey.publicKey.toHexString()
         
-        let pendingPairing = PairingType.Pending(
-            status: .responded,
+//        let pendingPairing = PairingType.Pending(
+//            status: .responded,
+//            topic: proposal.topic,
+//            relay: proposal.relay,
+//            self: PairingType.Participant(publicKey: selfPublicKey),
+//            proposal: proposal)
+//
+//        wcSubscriber.setSubscription(topic: proposal.topic)
+//        sequencesStore.create(topic: proposal.topic, sequenceState: .pending(pendingPairing))
+        
+        let pending = PairingSequence.Pending(
+            proposal: proposal,
+            status: .responded)
+        var pairingSequence = PairingSequence(
             topic: proposal.topic,
             relay: proposal.relay,
-            self: PairingType.Participant(publicKey: selfPublicKey),
-            proposal: proposal)
+            selfParticipant: PairingType.Participant(publicKey: selfPublicKey),
+            expiryDate: Date(timeIntervalSinceNow: TimeInterval(Time.day)),
+            pendingState: pending)
         
         wcSubscriber.setSubscription(topic: proposal.topic)
-        sequencesStore.create(topic: proposal.topic, sequenceState: .pending(pendingPairing))
+        try? sequencesStore.setSequence(pairingSequence)
+        
         // settle on topic B
         let agreementKeys = try! Crypto.X25519.generateAgreementKeys(
             peerPublicKey: Data(hex: proposal.proposer.publicKey),
@@ -52,20 +67,36 @@ final class PairingEngine {
         let settledTopic = agreementKeys.sharedSecret.sha256().toHexString()
         let selfParticipant = PairingType.Participant(publicKey: selfPublicKey)
         let controllerKey = proposal.proposer.controller ? proposal.proposer.publicKey : selfPublicKey
-        let settledPairing = PairingType.Settled(
-            topic: settledTopic,
-            relay: proposal.relay,
-            self: selfParticipant,
+//        let settledPairing = PairingType.Settled(
+//            topic: settledTopic,
+//            relay: proposal.relay,
+//            self: selfParticipant,
+//            peer: PairingType.Participant(publicKey: proposal.proposer.publicKey),
+//            permissions: PairingType.Permissions(
+//                jsonrpc: proposal.permissions.jsonrpc,
+//                controller: Controller(publicKey: controllerKey)),
+//            expiry: Int(Date().timeIntervalSince1970) + proposal.ttl,
+//            state: nil) // FIXME: State
+//
+//
+//        wcSubscriber.setSubscription(topic: settledTopic)
+//        sequencesStore.update(topic: proposal.topic, newTopic: settledTopic, sequenceState: .settled(settledPairing))
+        
+        let settled = PairingSequence.Settled(
             peer: PairingType.Participant(publicKey: proposal.proposer.publicKey),
             permissions: PairingType.Permissions(
                 jsonrpc: proposal.permissions.jsonrpc,
                 controller: Controller(publicKey: controllerKey)),
-            expiry: Int(Date().timeIntervalSince1970) + proposal.ttl,
             state: nil) // FIXME: State
+        let settledPairing = PairingSequence(
+            topic: settledTopic,
+            relay: proposal.relay,
+            selfParticipant: selfParticipant,
+            expiryDate: Date(timeIntervalSinceNow: TimeInterval(proposal.ttl)),
+            settledState: settled)
         
-                
         wcSubscriber.setSubscription(topic: settledTopic)
-        sequencesStore.update(topic: proposal.topic, newTopic: settledTopic, sequenceState: .settled(settledPairing))
+        try? sequencesStore.update(sequence: settledPairing, onTopic: proposal.topic)
         
         crypto.set(agreementKeys: agreementKeys, topic: settledTopic)
         crypto.set(privateKey: privateKey)
@@ -84,7 +115,8 @@ final class PairingEngine {
                 self?.wcSubscriber.removeSubscription(topic: proposal.topic)
                 self?.logger.debug("Success on wc_pairingApprove - settled topic - \(settledTopic)")
                 self?.update(topic: settledTopic)
-                completion(.success(settledPairing))
+                let pairingSuccess = Pairing(topic: settledTopic, peer: nil) // FIXME: peer?
+                completion(.success(pairingSuccess))
             case .failure(let error):
                 completion(.failure(error))
             }
@@ -92,7 +124,11 @@ final class PairingEngine {
     }
     
     private func update(topic: String) {
-        guard case .settled(var pairing) = sequencesStore.get(topic: topic) else {
+//        guard case .settled(var pairing) = sequencesStore.get(topic: topic) else {
+//            logger.debug("Could not find pairing for topic \(topic)")
+//            return
+//        }
+        guard var pairing = try? sequencesStore.getSequence(forTopic: topic) else {
             logger.debug("Could not find pairing for topic \(topic)")
             return
         }
@@ -101,8 +137,9 @@ final class PairingEngine {
         relayer.request(topic: topic, payload: request) { [unowned self] result in
             switch result {
             case .success(_):
-                pairing.state?.metadata = appMetadata
-                sequencesStore.update(topic: topic, newTopic: nil, sequenceState: .settled(pairing))
+                pairing.settled?.state?.metadata = appMetadata
+                try? sequencesStore.update(sequence: pairing, onTopic: topic)
+//                sequencesStore.update(topic: topic, newTopic: nil, sequenceState: .settled(pairing))
             case .failure(let error):
                 logger.error(error)
             }
@@ -127,13 +164,26 @@ final class PairingEngine {
         let proposal = PairingType.Proposal(topic: topic, relay: relay, proposer: proposer, signal: signal, permissions: permissions, ttl: getDefaultTTL())
         let `self` = PairingType.Participant(publicKey: publicKey)
         let pending = PairingType.Pending(status: .proposed, topic: topic, relay: relay, self: `self`, proposal: proposal)
-        sequencesStore.create(topic: topic, sequenceState: .pending(pending))
+//        sequencesStore.create(topic: topic, sequenceState: .pending(pending))
+        
+        let pendingPairing = PairingSequence(
+            topic: topic,
+            relay: relay,
+            selfParticipant: `self`,
+            expiryDate: Date(timeIntervalSinceNow: TimeInterval(Time.day)),
+            pendingState: PairingSequence.Pending(proposal: proposal, status: .proposed))
+        try? sequencesStore.setSequence(pendingPairing)
+        
         wcSubscriber.setSubscription(topic: topic)
         return pending
     }
     
     func ping(topic: String, completion: @escaping ((Result<Void, Error>) -> ())) {
-        guard let _ = sequencesStore.get(topic: topic) else {
+//        guard let _ = sequencesStore.get(topic: topic) else {
+//            logger.debug("Could not find pairing to ping for topic \(topic)")
+//            return
+//        }
+        guard sequencesStore.hasSequence(forTopic: topic) else {
             logger.debug("Could not find pairing to ping for topic \(topic)")
             return
         }
@@ -198,23 +248,31 @@ final class PairingEngine {
     }
     
     private func handlePairingUpdate(params:  PairingType.UpdateParams,topic: String, requestId: Int64) {
-        guard case .settled(var pairing) = sequencesStore.get(topic: topic) else {
+//        guard case .settled(var pairing) = sequencesStore.get(topic: topic) else {
+//            logger.debug("Could not find pairing for topic \(topic)")
+//            return
+//        }
+        guard var pairing = try? sequencesStore.getSequence(forTopic: topic) else {
             logger.debug("Could not find pairing for topic \(topic)")
             return
         }
-        guard pairing.peer.publicKey == pairing.permissions.controller.publicKey else {
+//        guard pairing.peer.publicKey == pairing.permissions.controller.publicKey else {
+        guard pairing.settled?.peerIsController == true else {
             let error = WalletConnectError.unauthrorized(.unauthorizedUpdateRequest)
             logger.error(error)
             respond(error: error, requestId: requestId, topic: topic)
             return
         }
+//        guard pairing.settled?.peer.publicKey == pairing.settled?.permissions
         let response = JSONRPCResponse<Bool>(id: requestId, result: true)
         relayer.respond(topic: topic, payload: response) { [unowned self] error in
             if let error = error {
                 logger.error(error)
             } else {
-                pairing.state = params.state
-                sequencesStore.update(topic: topic, newTopic: nil, sequenceState: .settled(pairing))
+//                pairing.state = params.state
+//                sequencesStore.update(topic: topic, newTopic: nil, sequenceState: .settled(pairing))
+                pairing.settled?.state = params.state
+                try? sequencesStore.update(sequence: pairing, onTopic: topic)
                 onPairingUpdate?(topic, params.state.metadata)
             }
         }
@@ -229,7 +287,7 @@ final class PairingEngine {
 
     private func handlePairingPayload(_ payload: PairingType.PayloadParams, for topic: String, requestId: Int64) {
         logger.debug("Will handle pairing payload")
-        guard let _ = sequencesStore.get(topic: topic) else {
+        guard sequencesStore.hasSequence(forTopic: topic) else {
             logger.error("Pairing for the topic: \(topic) does not exist")
             return
         }
@@ -251,7 +309,7 @@ final class PairingEngine {
         logger.debug("-------------------------------------")
         logger.debug("Paired client removed pairing - reason: \(deleteParams.reason.message), code: \(deleteParams.reason.code)")
         logger.debug("-------------------------------------")
-        sequencesStore.delete(topic: topic)
+        sequencesStore.delete(forTopic: topic)
         wcSubscriber.removeSubscription(topic: topic)
         let response = JSONRPCResponse<Bool>(id: requestId, result: true)
 //        relayer.respond(topic: topic, payload: response) { error in
@@ -261,11 +319,16 @@ final class PairingEngine {
     
     private func handlePairingApprove(approveParams: PairingType.ApproveParams, pendingTopic: String, reqestId: Int64) {
         logger.debug("Responder Client approved pairing on topic: \(pendingTopic)")
-        guard case let .pending(pairingPending) = sequencesStore.get(topic: pendingTopic) else {
-                  logger.debug("Could not find pending pairing associated with topic \(pendingTopic)")
-                  return
+//        guard case let .pending(pairingPending) = sequencesStore.get(topic: pendingTopic) else {
+//                  logger.debug("Could not find pending pairing associated with topic \(pendingTopic)")
+//                  return
+//        }
+        guard let pairing = try? sequencesStore.getSequence(forTopic: pendingTopic), let pairingPending = pairing.pending else {
+            return
         }
-        let selfPublicKey = Data(hex: pairingPending.`self`.publicKey)
+        
+//        let selfPublicKey = Data(hex: pairingPending.`self`.publicKey)
+        let selfPublicKey = Data(hex: pairing.selfParticipant.publicKey)
         let privateKey = try! crypto.getPrivateKey(for: selfPublicKey)!
         let peerPublicKey = Data(hex: approveParams.responder.publicKey)
         let agreementKeys = try! Crypto.X25519.generateAgreementKeys(peerPublicKey: peerPublicKey, privateKey: privateKey)
@@ -275,23 +338,41 @@ final class PairingEngine {
         let controllerKey = proposal.proposer.controller ? proposal.proposer.publicKey : peerPublicKey.toHexString()
         let controller = Controller(publicKey: controllerKey)
    
-        let settledPairing = PairingType.Settled(
+//        let settledPairing = PairingType.Settled(
+//            topic: settledTopic,
+//            relay: approveParams.relay,
+//            self: PairingType.Participant(publicKey: selfPublicKey.toHexString()),
+//            peer: PairingType.Participant(publicKey: approveParams.responder.publicKey),
+//            permissions: PairingType.Permissions(
+//                jsonrpc: proposal.permissions.jsonrpc,
+//                controller: controller),
+//            expiry: approveParams.expiry,
+//            state: approveParams.state)
+        
+//        sequencesStore.update(topic: proposal.topic, newTopic: settledTopic, sequenceState: .settled(settledPairing))
+        
+        let peer = PairingType.Participant(publicKey: approveParams.responder.publicKey)
+        let settledPairing = PairingSequence(
             topic: settledTopic,
             relay: approveParams.relay,
-            self: PairingType.Participant(publicKey: selfPublicKey.toHexString()),
-            peer: PairingType.Participant(publicKey: approveParams.responder.publicKey),
-            permissions: PairingType.Permissions(
-                jsonrpc: proposal.permissions.jsonrpc,
-                controller: controller),
-            expiry: approveParams.expiry,
-            state: approveParams.state)
+            selfParticipant: PairingType.Participant(publicKey: selfPublicKey.toHexString()),
+            expiryDate: Date(timeIntervalSinceNow: TimeInterval(approveParams.expiry)),
+            settledState: PairingSequence.Settled(
+                peer: peer,
+                permissions: PairingType.Permissions(
+                    jsonrpc: proposal.permissions.jsonrpc,
+                    controller: controller),
+                state: approveParams.state))
+//        try? sequencesStore.update(topic: proposal.topic, newTopic: settledTopic, sequenceState: settledPairing)
+        try? sequencesStore.update(sequence: settledPairing, onTopic: proposal.topic)
         
-        sequencesStore.update(topic: proposal.topic, newTopic: settledTopic, sequenceState: .settled(settledPairing))
         wcSubscriber.setSubscription(topic: settledTopic)
         wcSubscriber.removeSubscription(topic: proposal.topic)
         let response = JSONRPCResponse<Bool>(id: reqestId, result: true)
         relayer.respond(topic: proposal.topic, payload: response) { [weak self] error in
-            self?.onPairingApproved?(settledPairing, pendingTopic)
+            let pairing = Pairing(topic: settledPairing.topic, peer: nil) // FIXME: peer?
+            self?.onPairingApproved?(pairing, pendingTopic, settledPairing.relay)
+//            self?.onPairingApproved?(settledPairing, pendingTopic)
         }
     }
     

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -260,7 +260,7 @@ final class PairingEngine {
         logger.debug("-------------------------------------")
         logger.debug("Paired client removed pairing - reason: \(deleteParams.reason.message), code: \(deleteParams.reason.code)")
         logger.debug("-------------------------------------")
-        sequencesStore.delete(forTopic: topic)
+        sequencesStore.delete(topic: topic)
         wcSubscriber.removeSubscription(topic: topic)
         let response = JSONRPCResponse<Bool>(id: requestId, result: true)
 //        relayer.respond(topic: topic, payload: response) { error in

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -211,7 +211,7 @@ final class PairingEngine {
             logger.debug("Could not find pairing for topic \(topic)")
             return
         }
-        guard pairing.settled?.peerIsController == true else {
+        guard pairing.peerIsController else {
             let error = WalletConnectError.unauthrorized(.unauthorizedUpdateRequest)
             logger.error(error)
             respond(error: error, requestId: requestId, topic: topic)

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -118,7 +118,7 @@ final class SessionEngine {
         }
     }
     
-    func proposeSession(settledPairing: PairingType.Settled, permissions: SessionType.Permissions) {
+    func proposeSession(settledPairing: Pairing, permissions: SessionType.Permissions, relay: RelayProtocolOptions) {
         guard let pendingSessionTopic = generateTopic() else {
             logger.debug("Could not generate topic")
             return
@@ -129,9 +129,9 @@ final class SessionEngine {
         crypto.set(privateKey: privateKey)
         let proposer = SessionType.Proposer(publicKey: publicKey, controller: isController, metadata: metadata)
         let signal = SessionType.Signal(method: "pairing", params: SessionType.Signal.Params(topic: settledPairing.topic))
-        let proposal = SessionType.Proposal(topic: pendingSessionTopic, relay: settledPairing.relay, proposer: proposer, signal: signal, permissions: permissions, ttl: getDefaultTTL())
+        let proposal = SessionType.Proposal(topic: pendingSessionTopic, relay: relay, proposer: proposer, signal: signal, permissions: permissions, ttl: getDefaultTTL())
         let selfParticipant = SessionType.Participant(publicKey: publicKey, metadata: metadata)
-        let pending = SessionType.Pending(status: .proposed, topic: pendingSessionTopic, relay: settledPairing.relay, self: selfParticipant, proposal: proposal)
+        let pending = SessionType.Pending(status: .proposed, topic: pendingSessionTopic, relay: relay, self: selfParticipant, proposal: proposal)
         sequencesStore.create(topic: pendingSessionTopic, sequenceState: .pending(pending))
         wcSubscriber.setSubscription(topic: pendingSessionTopic)
         let request = PairingType.PayloadParams.Request(method: .sessionPropose, params: proposal)

--- a/Sources/WalletConnect/Pairing.swift
+++ b/Sources/WalletConnect/Pairing.swift
@@ -1,3 +1,6 @@
+/**
+ A representation of an active pairing connection.
+ */
 public struct Pairing {
     public let topic: String
     public let peer: AppMetadata?

--- a/Sources/WalletConnect/Pairing.swift
+++ b/Sources/WalletConnect/Pairing.swift
@@ -1,0 +1,4 @@
+public struct Pairing {
+    public let topic: String
+    public let peer: AppMetadata?
+}

--- a/Sources/WalletConnect/Storage/SequenceStore.swift
+++ b/Sources/WalletConnect/Storage/SequenceStore.swift
@@ -19,6 +19,10 @@ final class SequenceStore<T> where T: ExpirableSequence {
         self.storage = storage
         self.dateInitializer = dateInitializer
     }
+    
+    func hasSequence(forTopic topic: String) -> Bool {
+        (try? getSequence(forTopic: topic)) != nil
+    }
 
     func setSequence(_ sequence: T) throws {
         let encoded = try JSONEncoder().encode(sequence)

--- a/Sources/WalletConnect/Storage/SequenceStore.swift
+++ b/Sources/WalletConnect/Storage/SequenceStore.swift
@@ -49,7 +49,7 @@ final class SequenceStore<T> where T: ExpirableSequence {
         try setSequence(sequence)
     }
 
-    func delete(forTopic topic: String) {
+    func delete(topic: String) {
         storage.removeObject(forKey: topic)
     }
     

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -1,11 +1,12 @@
 import Foundation
 
 struct PairingSequence: ExpirableSequence {
+    
     let topic: String
     let relay: RelayProtocolOptions
     let selfParticipant: PairingType.Participant
     let expiryDate: Date
-    var sequenceState: Either<Pending, Settled>
+    private var sequenceState: Either<Pending, Settled>
 
     var pending: Pending? {
         get {
@@ -29,6 +30,23 @@ struct PairingSequence: ExpirableSequence {
         }
     }
     
+    var isSettled: Bool {
+        settled != nil
+    }
+}
+
+extension PairingSequence {
+    
+    init(topic: String, relay: RelayProtocolOptions, selfParticipant: PairingType.Participant, expiryDate: Date, pendingState: Pending) {
+        self.init(topic: topic, relay: relay, selfParticipant: selfParticipant, expiryDate: expiryDate, sequenceState: .left(pendingState))
+    }
+    
+    init(topic: String, relay: RelayProtocolOptions, selfParticipant: PairingType.Participant, expiryDate: Date, settledState: Settled) {
+        self.init(topic: topic, relay: relay, selfParticipant: selfParticipant, expiryDate: expiryDate, sequenceState: .right(settledState))
+    }
+}
+    
+extension PairingSequence {
     
     struct Pending: Codable {
         let proposal: PairingType.Proposal
@@ -44,25 +62,4 @@ struct PairingSequence: ExpirableSequence {
             peer.publicKey == permissions.controller.publicKey
         }
     }
-    
-    init(topic: String, relay: RelayProtocolOptions, selfParticipant: PairingType.Participant, expiryDate: Date, pendingState: Pending) {
-        self.init(topic: topic, relay: relay, selfParticipant: selfParticipant, expiryDate: expiryDate, sequenceState: .left(pendingState))
-    }
-    
-    init(topic: String, relay: RelayProtocolOptions, selfParticipant: PairingType.Participant, expiryDate: Date, settledState: Settled) {
-        self.init(topic: topic, relay: relay, selfParticipant: selfParticipant, expiryDate: expiryDate, sequenceState: .right(settledState))
-    }
-    
-    private init(topic: String, relay: RelayProtocolOptions, selfParticipant: PairingType.Participant, expiryDate: Date, sequenceState: Either<PairingSequence.Pending, PairingSequence.Settled>) {
-        self.topic = topic
-        self.relay = relay
-        self.selfParticipant = selfParticipant
-        self.expiryDate = expiryDate
-        self.sequenceState = sequenceState
-    }
-}
-
-public struct Pairing {
-    public let topic: String
-    public let peer: AppMetadata? // TODO: Remove optional, there's always a peer
 }

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -33,6 +33,10 @@ struct PairingSequence: ExpirableSequence {
     var isSettled: Bool {
         settled != nil
     }
+    
+    var peerIsController: Bool {
+        isSettled && settled?.peer.publicKey == settled?.permissions.controller.publicKey
+    }
 }
 
 extension PairingSequence {
@@ -57,9 +61,5 @@ extension PairingSequence {
         let peer: PairingType.Participant
         let permissions: PairingType.Permissions
         var state: PairingType.State?
-        
-        var peerIsController: Bool {
-            peer.publicKey == permissions.controller.publicKey
-        }
     }
 }

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -3,10 +3,33 @@ import Foundation
 struct PairingSequence: ExpirableSequence {
     let topic: String
     let relay: RelayProtocolOptions
-    let `self`: PairingType.Participant
+    let selfParticipant: PairingType.Participant
     let expiryDate: Date
-    let sequenceState: Either<Pending, Settled>
+    var sequenceState: Either<Pending, Settled>
 
+    var pending: Pending? {
+        get {
+            sequenceState.left
+        }
+        set {
+            if let pending = newValue {
+                sequenceState = .left(pending)
+            }
+        }
+    }
+    
+    var settled: Settled? {
+        get {
+            sequenceState.right
+        }
+        set {
+            if let settled = newValue {
+                sequenceState = .right(settled)
+            }
+        }
+    }
+    
+    
     struct Pending: Codable {
         let proposal: PairingType.Proposal
         let status: PairingType.Pending.PendingStatus
@@ -15,7 +38,27 @@ struct PairingSequence: ExpirableSequence {
     struct Settled: Codable {
         let peer: PairingType.Participant
         let permissions: PairingType.Permissions
-        let state: PairingType.State?
+        var state: PairingType.State?
+        
+        var peerIsController: Bool {
+            peer.publicKey == permissions.controller.publicKey
+        }
+    }
+    
+    init(topic: String, relay: RelayProtocolOptions, selfParticipant: PairingType.Participant, expiryDate: Date, pendingState: Pending) {
+        self.init(topic: topic, relay: relay, selfParticipant: selfParticipant, expiryDate: expiryDate, sequenceState: .left(pendingState))
+    }
+    
+    init(topic: String, relay: RelayProtocolOptions, selfParticipant: PairingType.Participant, expiryDate: Date, settledState: Settled) {
+        self.init(topic: topic, relay: relay, selfParticipant: selfParticipant, expiryDate: expiryDate, sequenceState: .right(settledState))
+    }
+    
+    private init(topic: String, relay: RelayProtocolOptions, selfParticipant: PairingType.Participant, expiryDate: Date, sequenceState: Either<PairingSequence.Pending, PairingSequence.Settled>) {
+        self.topic = topic
+        self.relay = relay
+        self.selfParticipant = selfParticipant
+        self.expiryDate = expiryDate
+        self.sequenceState = sequenceState
     }
 }
 

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct PairingSequence: ExpirableSequence {
+    let topic: String
+    let relay: RelayProtocolOptions
+    let `self`: PairingType.Participant
+    let expiryDate: Date
+    let sequenceState: Either<Pending, Settled>
+
+    struct Pending: Codable {
+        let proposal: PairingType.Proposal
+        let status: PairingType.Pending.PendingStatus
+    }
+
+    struct Settled: Codable {
+        let peer: PairingType.Participant
+        let permissions: PairingType.Permissions
+        let state: PairingType.State?
+    }
+}
+
+public struct Pairing {
+    public let topic: String
+    public let peer: AppMetadata? // TODO: Remove optional, there's always a peer
+}

--- a/Sources/WalletConnect/Types/Pairing/PairingSequenceState.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequenceState.swift
@@ -2,6 +2,8 @@
 import Foundation
 
 extension PairingType {
+    
+    // TODO: Evaluate if this type can be removed (fully replaced by PairingSequence) after session engine refactor.
     enum SequenceState: Codable, Equatable {
         case settled(Settled)
         case pending(Pending)

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -42,7 +42,6 @@ public final class WalletConnectClient {
         let serialiser = JSONRPCSerialiser(crypto: crypto)
         self.relay = WalletConnectRelay(networkRelayer: wakuRelay, jsonRpcSerialiser: serialiser, logger: logger)
         let sessionSequencesStore = SessionUserDefaultsStore(logger: logger)
-//        let pairingSequencesStore = PairingUserDefaultsStore(logger: logger)
         let pairingSequencesStore = SequenceStore<PairingSequence>(storage: keyValueStore)
         self.pairingEngine = PairingEngine(relay: relay, crypto: crypto, subscriber: WCSubscriber(relay: relay, logger: logger), sequencesStore: pairingSequencesStore, isController: isController, metadata: metadata, logger: logger)
         self.sessionEngine = SessionEngine(relay: relay, crypto: crypto, subscriber: WCSubscriber(relay: relay, logger: logger), sequencesStore: sessionSequencesStore, isController: isController, metadata: metadata, logger: logger)
@@ -54,9 +53,6 @@ public final class WalletConnectClient {
     public func connect(params: ConnectParams) throws -> String? {
         logger.debug("Connecting Application")
         if let topic = params.pairing?.topic {
-//            guard case .settled(let settledPairing) = pairingEngine.sequencesStore.get(topic: topic) else {
-//                throw WalletConnectError.InternalReason.noSequenceForTopic
-//            }
             guard let pairing = try? pairingEngine.sequencesStore.getSequence(forTopic: topic), pairing.settled != nil else {
                 throw WalletConnectError.InternalReason.noSequenceForTopic
             }

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -156,9 +156,8 @@ public final class WalletConnectClient {
         return sessions
     }
     
-    public func getSettledPairings() -> [PairingType.Settled] {
-//        pairingEngine.sequencesStore.getSettled()
-        fatalError()
+    public func getSettledPairings() -> [Pairing] {
+        pairingEngine.getSettledPairings()
     }
     
     //MARK: - Private

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -7,7 +7,7 @@ public protocol WalletConnectClientDelegate: AnyObject {
     func didReceive(sessionRequest: SessionRequest)
     func didReceive(notification: Notification, sessionTopic: String)
     func didSettle(session: Session)
-    func didSettle(pairing: PairingType.Settled)
+    func didSettle(pairing: Pairing)
     func didReject(sessionPendingTopic: String, reason: SessionType.Reason)
     func didDelete(sessionTopic: String, reason: SessionType.Reason)
     func didUpgrade(sessionTopic: String, permissions: SessionType.Permissions)
@@ -30,10 +30,10 @@ public final class WalletConnectClient {
     // MARK: - Public interface
 
     public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayURL: URL) {
-        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayURL: relayURL, logger: MuteLogger())
+        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayURL: relayURL, logger: MuteLogger(), keyValueStore: UserDefaults.standard)
     }
     
-    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayURL: URL, logger: BaseLogger = MuteLogger(), keychain: KeychainStorage = KeychainStorage()) {
+    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayURL: URL, logger: BaseLogger = MuteLogger(), keyValueStore: KeyValueStorage, keychain: KeychainStorage = KeychainStorage()) {
         self.metadata = metadata
         self.isController = isController
 //        try? keychain.deleteAll() // Use for cleanup while lifecycles are not handled yet, but FIXME whenever
@@ -42,7 +42,8 @@ public final class WalletConnectClient {
         let serialiser = JSONRPCSerialiser(crypto: crypto)
         self.relay = WalletConnectRelay(networkRelayer: wakuRelay, jsonRpcSerialiser: serialiser, logger: logger)
         let sessionSequencesStore = SessionUserDefaultsStore(logger: logger)
-        let pairingSequencesStore = PairingUserDefaultsStore(logger: logger)
+//        let pairingSequencesStore = PairingUserDefaultsStore(logger: logger)
+        let pairingSequencesStore = SequenceStore<PairingSequence>(storage: keyValueStore)
         self.pairingEngine = PairingEngine(relay: relay, crypto: crypto, subscriber: WCSubscriber(relay: relay, logger: logger), sequencesStore: pairingSequencesStore, isController: isController, metadata: metadata, logger: logger)
         self.sessionEngine = SessionEngine(relay: relay, crypto: crypto, subscriber: WCSubscriber(relay: relay, logger: logger), sequencesStore: sessionSequencesStore, isController: isController, metadata: metadata, logger: logger)
         setUpEnginesCallbacks()
@@ -53,11 +54,15 @@ public final class WalletConnectClient {
     public func connect(params: ConnectParams) throws -> String? {
         logger.debug("Connecting Application")
         if let topic = params.pairing?.topic {
-            guard case .settled(let settledPairing) = pairingEngine.sequencesStore.get(topic: topic) else {
+//            guard case .settled(let settledPairing) = pairingEngine.sequencesStore.get(topic: topic) else {
+//                throw WalletConnectError.InternalReason.noSequenceForTopic
+//            }
+            guard let pairing = try? pairingEngine.sequencesStore.getSequence(forTopic: topic), pairing.settled != nil else {
                 throw WalletConnectError.InternalReason.noSequenceForTopic
             }
             logger.debug("Proposing session on existing pairing")
-            sessionEngine.proposeSession(settledPairing: settledPairing, permissions: params.permissions)
+            
+            sessionEngine.proposeSession(settledPairing: Pairing(topic: pairing.topic, peer: nil), permissions: params.permissions, relay: pairing.relay)
             return nil
         } else {
             guard let pending = pairingEngine.propose(params) else {
@@ -127,7 +132,7 @@ public final class WalletConnectClient {
     }
     
     public func ping(topic: String, completion: @escaping ((Result<Void, Error>) -> ())) {
-        if pairingEngine.sequencesStore.get(topic: topic) != nil {
+        if pairingEngine.sequencesStore.hasSequence(forTopic: topic) {
             pairingEngine.ping(topic: topic) { result in
                 completion(result)
             }
@@ -156,7 +161,8 @@ public final class WalletConnectClient {
     }
     
     public func getSettledPairings() -> [PairingType.Settled] {
-        pairingEngine.sequencesStore.getSettled()
+//        pairingEngine.sequencesStore.getSettled()
+        fatalError()
     }
     
     //MARK: - Private
@@ -165,14 +171,14 @@ public final class WalletConnectClient {
         pairingEngine.onSessionProposal = { [unowned self] proposal in
             proposeSession(proposal: proposal)
         }
-        pairingEngine.onPairingApproved = { [unowned self] settledPairing, pendingTopic in
+        pairingEngine.onPairingApproved = { [unowned self] settledPairing, pendingTopic, relayOptions in
             delegate?.didSettle(pairing: settledPairing)
             guard let permissions = sessionPermissions[pendingTopic] else {
                 logger.debug("Cound not find permissions for pending topic: \(pendingTopic)")
                 return
             }
             sessionPermissions[pendingTopic] = nil
-            sessionEngine.proposeSession(settledPairing: settledPairing, permissions: permissions)
+            sessionEngine.proposeSession(settledPairing: settledPairing, permissions: permissions, relay: relayOptions)
         }
         sessionEngine.onSessionApproved = { [unowned self] settledSession in
             let session = Session(topic: settledSession.topic, peer: settledSession.peer.metadata)

--- a/Tests/IntegrationTests/ClientDelegate.swift
+++ b/Tests/IntegrationTests/ClientDelegate.swift
@@ -5,7 +5,7 @@ import Foundation
 class ClientDelegate: WalletConnectClientDelegate {
     var client: WalletConnectClient
     var onSessionSettled: ((Session)->())?
-    var onPairingSettled: ((PairingType.Settled)->())?
+    var onPairingSettled: ((Pairing)->())?
     var onSessionProposal: ((SessionProposal)->())?
     var onSessionRequest: ((SessionRequest)->())?
     var onSessionRejected: ((String, SessionType.Reason)->())?
@@ -26,7 +26,7 @@ class ClientDelegate: WalletConnectClientDelegate {
     func didSettle(session: Session) {
         onSessionSettled?(session)
     }
-    func didSettle(pairing: PairingType.Settled) {
+    func didSettle(pairing: Pairing) {
         onPairingSettled?(pairing)
     }
     func didReceive(sessionProposal: SessionProposal) {

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -22,7 +22,6 @@ final class ClientTests: XCTestCase {
             logger: logger,
             keyValueStore: RuntimeKeyValueStorage(),
             keychain: KeychainStorage(keychainService: KeychainServiceFake()))
-//        client.pairingEngine.sequencesStore = PairingDictionaryStore(logger: logger)
         client.sessionEngine.sequencesStore = SessionDictionaryStore(logger: logger)
         return ClientDelegate(client: client)
     }
@@ -303,7 +302,7 @@ final class ClientTests: XCTestCase {
             XCTAssertEqual(notification, notificationParams)
             proposerReceivesNotificationExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: 13.0, handler: nil)
     }
     
     func testSessionNotificationFails() {

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -20,8 +20,9 @@ final class ClientTests: XCTestCase {
             isController: isController,
             relayURL: url,
             logger: logger,
+            keyValueStore: RuntimeKeyValueStorage(),
             keychain: KeychainStorage(keychainService: KeychainServiceFake()))
-        client.pairingEngine.sequencesStore = PairingDictionaryStore(logger: logger)
+//        client.pairingEngine.sequencesStore = PairingDictionaryStore(logger: logger)
         client.sessionEngine.sequencesStore = SessionDictionaryStore(logger: logger)
         return ClientDelegate(client: client)
     }

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -260,7 +260,7 @@ final class ClientTests: XCTestCase {
         responder.onSessionUpgrade = { topic, permissions in
             responderSessionUpgradeExpectation.fulfill()
         }
-        waitForExpectations(timeout: defaultTimeout, handler: nil)
+        waitForExpectations(timeout: 3.0, handler: nil)
     }
     
     func testSuccessfulSessionUpdate() {

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -4,9 +4,13 @@ import XCTest
 @testable import WalletConnect
 
 final class ClientTests: XCTestCase {
+    
+    let defaultTimeout: TimeInterval = 5.0
+    
     let url = URL(string: "wss://staging.walletconnect.org")! // TODO: Change to new URL
     var proposer: ClientDelegate!
     var responder: ClientDelegate!
+    
     override func setUp() {
         proposer = Self.makeClientDelegate(isController: false, url: url, prefix: "🍏P")
         responder = Self.makeClientDelegate(isController: true, url: url, prefix: "🍎R")
@@ -40,7 +44,7 @@ final class ClientTests: XCTestCase {
         proposer.onPairingSettled = { pairing in
             proposerSettlesPairingExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testNewSession() {
@@ -65,7 +69,7 @@ final class ClientTests: XCTestCase {
 //            XCTAssertEqual(account, sessionSettled.state.accounts[0])
             proposerSettlesSessionExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testNewSessionOnExistingPairing() {
@@ -96,7 +100,7 @@ final class ClientTests: XCTestCase {
                 initiatedSecondSession = true
             }
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testResponderRejectsSession() {
@@ -112,7 +116,7 @@ final class ClientTests: XCTestCase {
             XCTAssertEqual(reason.code, WalletConnectError.internal(.notApproved).code)
             sessionRejectExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testDeleteSession() {
@@ -130,7 +134,7 @@ final class ClientTests: XCTestCase {
         responder.onSessionDelete = {
             sessionDeleteExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testProposerRequestSessionPayload() {
@@ -167,7 +171,7 @@ final class ClientTests: XCTestCase {
             self.responder.client.respond(topic: sessionRequest.topic, response: jsonrpcResponse)
             requestExpectation.fulfill()
         }
-        waitForExpectations(timeout: 4.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testPairingPing() {
@@ -183,7 +187,7 @@ final class ClientTests: XCTestCase {
                 proposerReceivesPingResponseExpectation.fulfill()
             }
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     
@@ -202,7 +206,7 @@ final class ClientTests: XCTestCase {
                 proposerReceivesPingResponseExpectation.fulfill()
             }
         }
-        waitForExpectations(timeout: 4.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testSuccessfulSessionUpgrade() {
@@ -230,7 +234,7 @@ final class ClientTests: XCTestCase {
             XCTAssertTrue(permissions.jsonrpc.methods.isSuperset(of: upgradePermissions.methods))
             responderSessionUpgradeExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testSessionUpgradeFailsOnNonControllerRequest() {
@@ -256,7 +260,7 @@ final class ClientTests: XCTestCase {
         responder.onSessionUpgrade = { topic, permissions in
             responderSessionUpgradeExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testSuccessfulSessionUpdate() {
@@ -282,7 +286,7 @@ final class ClientTests: XCTestCase {
             XCTAssertEqual(accounts, updateAccounts)
             proposerSessionUpdateExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testSessionNotificationSucceeds() {
@@ -302,7 +306,7 @@ final class ClientTests: XCTestCase {
             XCTAssertEqual(notification, notificationParams)
             proposerReceivesNotificationExpectation.fulfill()
         }
-        waitForExpectations(timeout: 13.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testSessionNotificationFails() {
@@ -325,7 +329,7 @@ final class ClientTests: XCTestCase {
             XCTFail()
             proposerReceivesNotificationExpectation.fulfill()
         }
-        waitForExpectations(timeout: 2.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testPairingUpdate() {
@@ -338,7 +342,7 @@ final class ClientTests: XCTestCase {
             XCTAssertNotNil(appMetadata)
             proposerReceivesPairingUpdateExpectation.fulfill()
         }
-        waitForExpectations(timeout: 3.0, handler: nil)
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 }
 

--- a/Tests/WalletConnectTests/PairingEnginTests.swift
+++ b/Tests/WalletConnectTests/PairingEnginTests.swift
@@ -16,7 +16,8 @@ class PairingEngineTests: XCTestCase {
         subscriber = MockedSubscriber()
         let meta = AppMetadata(name: nil, description: nil, url: nil, icons: nil)
         let logger = MuteLogger()
-        engine = PairingEngine(relay: relay, crypto: crypto, subscriber: subscriber, sequencesStore: PairingDictionaryStore(logger: logger), isController: false, metadata: meta, logger: logger)
+        let store = SequenceStore<PairingSequence>(storage: RuntimeKeyValueStorage())
+        engine = PairingEngine(relay: relay, crypto: crypto, subscriber: subscriber, sequencesStore: store, isController: false, metadata: meta, logger: logger)
     }
 
     override func tearDown() {
@@ -28,7 +29,8 @@ class PairingEngineTests: XCTestCase {
     func testNotifyOnSessionProposal() {
         let topic = "1234"
         let proposalExpectation = expectation(description: "on session proposal is called after pairing payload")
-        engine.sequencesStore.create(topic: topic, sequenceState: sequencePendingState)
+//        engine.sequencesStore.create(topic: topic, sequenceState: sequencePendingState)
+        try? engine.sequencesStore.setSequence(pendingPairing)
         let subscriptionPayload = WCRequestSubscriptionPayload(topic: topic, clientSynchJsonRpc: sessionProposal)
         engine.onSessionProposal = { (_) in
             proposalExpectation.fulfill()
@@ -44,3 +46,5 @@ fileprivate let sessionProposal = ClientSynchJSONRPC(id: 0,
                                                      params: ClientSynchJSONRPC.Params.pairingPayload(PairingType.PayloadParams(request: PairingType.PayloadParams.Request(method: .sessionPropose, params: SessionType.ProposeParams(topic: "", relay: RelayProtocolOptions(protocol: "", params: []), proposer: SessionType.Proposer(publicKey: "", controller: false, metadata: AppMetadata(name: nil, description: nil, url: nil, icons: nil)), signal: SessionType.Signal(method: "", params: SessionType.Signal.Params(topic: "")), permissions: SessionType.Permissions(blockchain: SessionType.Blockchain(chains: []), jsonrpc: SessionType.JSONRPC(methods: []), notifications: SessionType.Notifications(types: [])), ttl: 100)))))
 
 fileprivate let sequencePendingState = PairingType.SequenceState.pending(PairingType.Pending(status: PairingType.Pending.PendingStatus(rawValue: "proposed")!, topic: "1234", relay: RelayProtocolOptions(protocol: "", params: nil), self: PairingType.Participant(publicKey: ""), proposal: PairingType.Proposal(topic: "", relay: RelayProtocolOptions(protocol: "", params: nil), proposer: PairingType.Proposer(publicKey: "", controller: false), signal: PairingType.Signal(params: PairingType.Signal.Params(uri: "")), permissions: PairingType.ProposedPermissions(jsonrpc: PairingType.JSONRPC(methods: [])), ttl: 100)))
+
+fileprivate let pendingPairing = PairingSequence(topic: "1234", relay: RelayProtocolOptions(protocol: "", params: nil), selfParticipant: PairingType.Participant(publicKey: ""), expiryDate: Date(timeIntervalSinceNow: 10), pendingState: PairingSequence.Pending(proposal: PairingType.Proposal(topic: "", relay: RelayProtocolOptions(protocol: "", params: nil), proposer: PairingType.Proposer(publicKey: "", controller: false), signal: PairingType.Signal(params: PairingType.Signal.Params(uri: "")), permissions: PairingType.ProposedPermissions(jsonrpc: PairingType.JSONRPC(methods: [])), ttl: 100), status: .proposed))

--- a/Tests/WalletConnectTests/SequenceStoreTests.swift
+++ b/Tests/WalletConnectTests/SequenceStoreTests.swift
@@ -44,6 +44,7 @@ final class SequenceStoreTests: XCTestCase {
         let sequence = stubSequence()
         try? sut.setSequence(sequence)
         let retrieved = try? sut.getSequence(forTopic: sequence.topic)
+        XCTAssertTrue(sut.hasSequence(forTopic: sequence.topic))
         XCTAssertEqual(retrieved, sequence)
     }
     
@@ -76,12 +77,25 @@ final class SequenceStoreTests: XCTestCase {
         try? sut.setSequence(sequence)
         sut.delete(forTopic: sequence.topic)
         let retrieved = try? sut.getSequence(forTopic: sequence.topic)
+        XCTAssertFalse(sut.hasSequence(forTopic: sequence.topic))
         XCTAssertNil(retrieved)
     }
     
     // MARK: - Expiration Tests
     
-    func testExpiration() {
+    func testHasSequenceExpiration() {
+        let sequence = stubSequence()
+        var expiredTopic: String? = nil
+        sut.onSequenceExpiration = { expiredTopic = $0 }
+        
+        try? sut.setSequence(sequence)
+        timeTraveler.travel(by: defaultTime)
+        
+        XCTAssertFalse(sut.hasSequence(forTopic: sequence.topic))
+        XCTAssertEqual(expiredTopic, sequence.topic)
+    }
+    
+    func testGetSequenceExpiration() {
         let sequence = stubSequence()
         var expiredTopic: String? = nil
         sut.onSequenceExpiration = { expiredTopic = $0 }

--- a/Tests/WalletConnectTests/SequenceStoreTests.swift
+++ b/Tests/WalletConnectTests/SequenceStoreTests.swift
@@ -75,7 +75,7 @@ final class SequenceStoreTests: XCTestCase {
     func testDelete() {
         let sequence = stubSequence()
         try? sut.setSequence(sequence)
-        sut.delete(forTopic: sequence.topic)
+        sut.delete(topic: sequence.topic)
         let retrieved = try? sut.getSequence(forTopic: sequence.topic)
         XCTAssertFalse(sut.hasSequence(forTopic: sequence.topic))
         XCTAssertNil(retrieved)


### PR DESCRIPTION
closes #124

Integrates the sequence store to the pairing engine by using expirable pairings to store pairing data. Includes some code refactor and a public `Pairing` type to adapt the internal pairing models and expose only the necessary data to the host app.