### PR TITLE
#126 handle non wc methods

### DIFF
--- a/Example/ExampleApp/Proposer/ProposerViewController.swift
+++ b/Example/ExampleApp/Proposer/ProposerViewController.swift
@@ -13,7 +13,7 @@ final class ProposerViewController: UIViewController {
             metadata: metadata,
             apiKey: "",
             isController: true,
-            relayURL: URL(string: "wss://relay.walletconnect.org")!
+            relayHost: "relay.walletconnect.org"
         )
     }()
     

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -13,7 +13,7 @@ final class ResponderViewController: UIViewController {
             metadata: metadata,
             apiKey: "",
             isController: true,
-            relayURL: URL(string: "wss://relay.walletconnect.org")!
+            relayHost: "relay.walletconnect.org"
         )
     }()
     

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -12,7 +12,7 @@ final class PairingEngine {
     var onPairingUpdate: ((String, AppMetadata)->())?
     private var appMetadata: AppMetadata
     private var publishers = [AnyCancellable]()
-    private let logger: BaseLogger
+    private let logger: ConsoleLogger
     
     init(relay: WalletConnectRelaying,
          crypto: Crypto,
@@ -20,7 +20,7 @@ final class PairingEngine {
          sequencesStore: SequenceStore<PairingSequence>,
          isController: Bool,
          metadata: AppMetadata,
-         logger: BaseLogger) {
+         logger: ConsoleLogger) {
         self.relayer = relay
         self.crypto = crypto
         self.wcSubscriber = subscriber

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -197,7 +197,7 @@ final class PairingEngine {
             case .pairingPing(_):
                 self.handlePairingPing(topic: topic, requestId: requestId)
             default:
-                logger.warn("Warning: Pairing Engine - Unexpected method type received from subscriber")
+                logger.warn("Warning: Pairing Engine - Unexpected method type: \(subscriptionPayload.clientSynchJsonRpc.method) received from subscriber")
             }
         }
     }

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -188,12 +188,8 @@ final class PairingEngine {
             switch subscriptionPayload.clientSynchJsonRpc.params {
             case .pairingApprove(let approveParams):
                 handlePairingApprove(approveParams: approveParams, pendingTopic: topic, requestId: requestId)
-            case .pairingReject(_):
-                fatalError("Not Implemented")
             case .pairingUpdate(let updateParams):
                 handlePairingUpdate(params: updateParams, topic: topic, requestId: requestId)
-            case .pairingUpgrade(_):
-                fatalError("Not Implemented")
             case .pairingDelete(let deleteParams):
                 handlePairingDelete(deleteParams, topic: topic, requestId: requestId)
             case .pairingPayload(let pairingPayload):
@@ -201,7 +197,7 @@ final class PairingEngine {
             case .pairingPing(_):
                 self.handlePairingPing(topic: topic, requestId: requestId)
             default:
-                fatalError("not expected method type")
+                logger.warn("Warning: Pairing Engine - Unexpected method type received from subscriber")
             }
         }
     }

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -303,7 +303,7 @@ final class SessionEngine {
             case .sessionNotification(let notificationParams):
                 handleSessionNotification(topic: topic, notificationParams: notificationParams, requestId: requestId)
             default:
-                logger.warn("Warning: Session Engine - Unexpected method type received from subscriber")
+                logger.warn("Warning: Session Engine - Unexpected method type: \(subscriptionPayload.clientSynchJsonRpc.method) received from subscriber")
             }
         }
     }

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -17,7 +17,7 @@ final class SessionEngine {
     var onNotificationReceived: ((String, SessionType.NotificationParams)->())?
     private var publishers = [AnyCancellable]()
 
-    private let logger: BaseLogger
+    private let logger: ConsoleLogger
 
     init(relay: WalletConnectRelaying,
          crypto: Crypto,
@@ -25,7 +25,7 @@ final class SessionEngine {
          sequencesStore: SessionSequencesStore,
          isController: Bool,
          metadata: AppMetadata,
-         logger: BaseLogger) {
+         logger: ConsoleLogger) {
         self.relayer = relay
         self.crypto = crypto
         self.metadata = metadata

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -303,7 +303,7 @@ final class SessionEngine {
             case .sessionNotification(let notificationParams):
                 handleSessionNotification(topic: topic, notificationParams: notificationParams, requestId: requestId)
             default:
-                fatalError("unexpected method type")
+                logger.warn("Warning: Session Engine - Unexpected method type received from subscriber")
             }
         }
     }

--- a/Sources/WalletConnect/JsonRpcHistory/JsonRpcHistory.swift
+++ b/Sources/WalletConnect/JsonRpcHistory/JsonRpcHistory.swift
@@ -11,9 +11,9 @@ protocol JsonRpcHistoryRecording {
 
 class JsonRpcHistory: JsonRpcHistoryRecording {
     let storage: KeyValueStore<JsonRpcRecord>
-    let logger: BaseLogger
+    let logger: ConsoleLogger
     
-    init(logger: BaseLogger, keyValueStorage: KeyValueStorage) {
+    init(logger: ConsoleLogger, keyValueStorage: KeyValueStorage) {
         self.logger = logger
         self.storage = KeyValueStore<JsonRpcRecord>(defaults: keyValueStorage)
     }

--- a/Sources/WalletConnect/Logger.swift
+++ b/Sources/WalletConnect/Logger.swift
@@ -24,10 +24,10 @@ public class ConsoleLogger {
         }
     }
     
-    func error(_ items: Any..., file: String = #file, function: String = #function, line: Int = #line ) {
-        if loggingLevel >= .error {
+    func info(_ items: Any...) {
+        if loggingLevel >= .info {
             items.forEach {
-                Swift.print("\(suffix) Error in File: \(file), Function: \(function), Line: \(line) - \($0)")
+                Swift.print("\(suffix) \($0)")
             }
         }
     }
@@ -39,11 +39,20 @@ public class ConsoleLogger {
             }
         }
     }
+    
+    func error(_ items: Any..., file: String = #file, function: String = #function, line: Int = #line ) {
+        if loggingLevel >= .error {
+            items.forEach {
+                Swift.print("\(suffix) Error in File: \(file), Function: \(function), Line: \(line) - \($0)")
+            }
+        }
+    }
 }
 
 public enum LoggingLevel: Comparable {
     case off
     case error
     case warn
+    case info
     case debug
 }

--- a/Sources/WalletConnect/Logger.swift
+++ b/Sources/WalletConnect/Logger.swift
@@ -14,6 +14,11 @@ class BaseLogger {
     func error(_ items: Any..., file: String = #file, function: String = #function, line: Int = #line ) {
         fatalError("Logging Subclass shoud implement the method")
     }
+    
+    func warn(_ items: Any...) {
+        fatalError("Logging Subclass shoud implement the method")
+    }
+    
 }
 
 class ConsoleLogger: BaseLogger {
@@ -37,9 +42,18 @@ class ConsoleLogger: BaseLogger {
         }
         #endif
     }
+    
+    override func warn(_ items: Any...) {
+        #if DEBUG
+        items.forEach {
+            Swift.print("\(suffix) ⚠️ \($0)")
+        }
+        #endif
+    }
 }
 
 class MuteLogger: BaseLogger {
     override func debug(_ items: Any...) {}
     override func error(_ items: Any..., file: String = #file, function: String = #function, line: Int = #line ) {}
+    override func warn(_ items: Any...) {}
 }

--- a/Sources/WalletConnect/Logger.swift
+++ b/Sources/WalletConnect/Logger.swift
@@ -2,58 +2,48 @@
 
 import Foundation
 
-class BaseLogger {
-    var suffix: String
-    init(suffix: String = "") {
-        self.suffix = suffix
+
+public class ConsoleLogger {
+    private var loggingLevel: LoggingLevel
+    private var suffix: String
+    
+    public func setLogging(level: LoggingLevel) {
+        self.loggingLevel = level
     }
+
+    init(suffix: String? = nil, loggingLevel: LoggingLevel = .warn) {
+        self.suffix = suffix ?? ""
+        self.loggingLevel = loggingLevel
+    }
+    
     func debug(_ items: Any...) {
-        fatalError("Logging Subclass shoud implement the method")
+        if loggingLevel >= .debug {
+            items.forEach {
+                Swift.print("\(suffix) \($0)")
+            }
+        }
     }
     
     func error(_ items: Any..., file: String = #file, function: String = #function, line: Int = #line ) {
-        fatalError("Logging Subclass shoud implement the method")
+        if loggingLevel >= .error {
+            items.forEach {
+                Swift.print("\(suffix) Error in File: \(file), Function: \(function), Line: \(line) - \($0)")
+            }
+        }
     }
     
     func warn(_ items: Any...) {
-        fatalError("Logging Subclass shoud implement the method")
-    }
-    
-}
-
-class ConsoleLogger: BaseLogger {
-    
-    override init(suffix: String = "") {
-        super.init(suffix: suffix)
-    }
-    
-    override func debug(_ items: Any...) {
-        #if DEBUG
-        items.forEach {
-            Swift.print("\(suffix) \($0)")
+        if loggingLevel >= .warn {
+            items.forEach {
+                Swift.print("\(suffix) ⚠️ \($0)")
+            }
         }
-        #endif
-    }
-    
-    override func error(_ items: Any..., file: String = #file, function: String = #function, line: Int = #line ) {
-        #if DEBUG
-        items.forEach {
-            Swift.print("\(suffix) Error in File: \(file), Function: \(function), Line: \(line) - \($0)")
-        }
-        #endif
-    }
-    
-    override func warn(_ items: Any...) {
-        #if DEBUG
-        items.forEach {
-            Swift.print("\(suffix) ⚠️ \($0)")
-        }
-        #endif
     }
 }
 
-class MuteLogger: BaseLogger {
-    override func debug(_ items: Any...) {}
-    override func error(_ items: Any..., file: String = #file, function: String = #function, line: Int = #line ) {}
-    override func warn(_ items: Any...) {}
+public enum LoggingLevel: Comparable {
+    case off
+    case error
+    case warn
+    case debug
 }

--- a/Sources/WalletConnect/Relay/NetworkRelaying.swift
+++ b/Sources/WalletConnect/Relay/NetworkRelaying.swift
@@ -165,4 +165,12 @@ class WakuNetworkRelay: NetworkRelaying {
             }
         }
     }
+    
+    static func makeRelayUrl(host: String, apiKey: String) -> URL {
+        var components = URLComponents()
+        components.scheme = "wss"
+        components.host = host
+        components.queryItems = [URLQueryItem(name: "apiKey", value: apiKey)]
+        return components.url!
+    }
 }

--- a/Sources/WalletConnect/Relay/NetworkRelaying.swift
+++ b/Sources/WalletConnect/Relay/NetworkRelaying.swift
@@ -34,9 +34,9 @@ class WakuNetworkRelay: NetworkRelaying {
         requestAcknowledgePublisherSubject.eraseToAnyPublisher()
     }
     private let requestAcknowledgePublisherSubject = PassthroughSubject<JSONRPCResponse<Bool>, Never>()
-    let logger: BaseLogger
+    let logger: ConsoleLogger
     init(transport: JSONRPCTransporting,
-         logger: BaseLogger) {
+         logger: ConsoleLogger) {
         self.logger = logger
         self.transport = transport
         setUpBindings()

--- a/Sources/WalletConnect/Relay/WalletConnectRelay.swift
+++ b/Sources/WalletConnect/Relay/WalletConnectRelay.swift
@@ -142,6 +142,8 @@ class WalletConnectRelay: WalletConnectRelaying {
             handleJsonRpcResponse(response: deserialisedJsonRpcResponse)
         } else if let deserialisedJsonRpcError: JSONRPCErrorResponse = jsonRpcSerialiser.tryDeserialise(topic: topic, message: message) {
             handleJsonRpcErrorResponse(response: deserialisedJsonRpcError)
+        } else {
+            logger.warn("Warning: WalletConnect Relay - Received unknown object type from networking relay")
         }
     }
     

--- a/Sources/WalletConnect/Relay/WalletConnectRelay.swift
+++ b/Sources/WalletConnect/Relay/WalletConnectRelay.swift
@@ -89,6 +89,8 @@ class WalletConnectRelay: WalletConnectRelaying {
                         }
                 }
             }
+        } catch WalletConnectError.internal(.jsonRpcDuplicateDetected) {
+            logger.info("Info: Json Rpc Duplicate Detected")
         } catch {
             logger.error(error)
         }
@@ -102,6 +104,8 @@ class WalletConnectRelay: WalletConnectRelaying {
             networkRelayer.publish(topic: topic, payload: message) { [weak self] error in
                 completion(error)
             }
+        } catch WalletConnectError.internal(.jsonRpcDuplicateDetected) {
+            logger.info("Info: Json Rpc Duplicate Detected")
         } catch {
             completion(error)
         }
@@ -152,6 +156,8 @@ class WalletConnectRelay: WalletConnectRelaying {
             try jsonRpcHistory.set(topic: topic, request: request)
             let payload = WCRequestSubscriptionPayload(topic: topic, clientSynchJsonRpc: request)
             clientSynchJsonRpcPublisherSubject.send(payload)
+        } catch WalletConnectError.internal(.jsonRpcDuplicateDetected) {
+            logger.info("Info: Json Rpc Duplicate Detected")
         } catch {
             logger.error(error)
         }
@@ -161,8 +167,8 @@ class WalletConnectRelay: WalletConnectRelaying {
         do {
             try jsonRpcHistory.resolve(response: JsonRpcResponseTypes.response(response))
             wcResponsePublisherSubject.send(.response(response))
-        } catch {
-            logger.error(error)
+        } catch  {
+            logger.info("Info: \(error.localizedDescription)")
         }
     }
     
@@ -171,7 +177,7 @@ class WalletConnectRelay: WalletConnectRelaying {
             try jsonRpcHistory.resolve(response: JsonRpcResponseTypes.error(response))
             wcResponsePublisherSubject.send(.error(response))
         } catch {
-            logger.error(error)
+            logger.info("Info: \(error.localizedDescription)")
         }
     }
 }

--- a/Sources/WalletConnect/Relay/WalletConnectRelay.swift
+++ b/Sources/WalletConnect/Relay/WalletConnectRelay.swift
@@ -52,11 +52,11 @@ class WalletConnectRelay: WalletConnectRelaying {
         wcResponsePublisherSubject.eraseToAnyPublisher()
     }
     private let wcResponsePublisherSubject = PassthroughSubject<JsonRpcResponseTypes, Never>()
-    let logger: BaseLogger
+    let logger: ConsoleLogger
     
     init(networkRelayer: NetworkRelaying,
          jsonRpcSerialiser: JSONRPCSerialising,
-         logger: BaseLogger,
+         logger: ConsoleLogger,
          jsonRpcHistory: JsonRpcHistoryRecording) {
         self.networkRelayer = networkRelayer
         self.jsonRpcSerialiser = jsonRpcSerialiser

--- a/Sources/WalletConnect/Sequences/DictionarySequencesStore.swift
+++ b/Sources/WalletConnect/Sequences/DictionarySequencesStore.swift
@@ -30,9 +30,9 @@ class SessionDictionaryStore: DictionaryStore<SessionType.SequenceState>, Sessio
 class DictionaryStore<T> {
     private let serialQueue = DispatchQueue(label: "sequence queue: \(UUID().uuidString)")
     private var sequences = [String: T]()
-    private let logger: BaseLogger
+    private let logger: ConsoleLogger
 
-    init(logger: BaseLogger) {
+    init(logger: ConsoleLogger) {
         self.logger = logger
     }
     

--- a/Sources/WalletConnect/Sequences/UserDefaultsSequencesStore.swift
+++ b/Sources/WalletConnect/Sequences/UserDefaultsSequencesStore.swift
@@ -29,9 +29,9 @@ class SessionUserDefaultsStore: UserDefaultsStore<SessionType.SequenceState>, Se
 
 class UserDefaultsStore<T: Codable> {
     private var defaults = UserDefaults.standard
-    private let logger: BaseLogger
+    private let logger: ConsoleLogger
 
-    init(logger: BaseLogger) {
+    init(logger: ConsoleLogger) {
         self.logger = logger
     }
     

--- a/Sources/WalletConnect/Subscription/WCSubscribing.swift
+++ b/Sources/WalletConnect/Subscription/WCSubscribing.swift
@@ -14,11 +14,11 @@ class WCSubscriber: WCSubscribing {
     private let concurrentQueue = DispatchQueue(label: "wc subscriber queue: \(UUID().uuidString)",
                                                 attributes: .concurrent)
     private var publishers = [AnyCancellable]()
-    private let logger: BaseLogger
+    private let logger: ConsoleLogger
     var topics: [String] = []
 
     init(relay: WalletConnectRelaying,
-         logger: BaseLogger) {
+         logger: ConsoleLogger) {
         self.relay = relay
         self.logger = logger
         setSubscribingForPayloads()

--- a/Sources/WalletConnect/Types/Pairing/ClientSynchronisation/PairingPayloadParams.swift
+++ b/Sources/WalletConnect/Types/Pairing/ClientSynchronisation/PairingPayloadParams.swift
@@ -13,15 +13,3 @@ extension PairingType.PayloadParams {
         let params: SessionType.ProposeParams
     }
 }
-
-extension PairingType.PayloadParams.Request {
-    enum Params: Codable, Equatable {
-        init(from decoder: Decoder) throws {
-            fatalError("not implemented")
-        }
-        
-        func encode(to encoder: Encoder) throws {
-            fatalError("not implemented")
-        }
-    }
-}

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -24,18 +24,19 @@ public final class WalletConnectClient {
     private let relay: WalletConnectRelaying
     private let crypto: Crypto
     private var sessionPermissions: [String: SessionType.Permissions] = [:]
-    var logger: BaseLogger = ConsoleLogger()
+    public let logger: ConsoleLogger
     private let secureStorage = SecureStorage()
     
     // MARK: - Public interface
 
     public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, keyValueStore: KeyValueStorage = UserDefaults.standard) {
-        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayHost: relayHost, logger: MuteLogger(), keyValueStore: keyValueStore)
+        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayHost: relayHost, keyValueStore: keyValueStore)
     }
     
-    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, logger: BaseLogger = MuteLogger(), keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage) {
+    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, logger: ConsoleLogger = ConsoleLogger(loggingLevel: .off), keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage) {
         self.metadata = metadata
         self.isController = isController
+        self.logger = logger
 //        try? keychain.deleteAll() // Use for cleanup while lifecycles are not handled yet, but FIXME whenever
         self.crypto = Crypto(keychain: keychain)
         let relayUrl = WakuNetworkRelay.makeRelayUrl(host: relayHost, apiKey: apiKey)

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -29,17 +29,17 @@ public final class WalletConnectClient {
     
     // MARK: - Public interface
 
-
     public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayURL: URL, keyValueStore: KeyValueStorage = UserDefaults.standard) {
         self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayURL: relayURL, logger: MuteLogger(), keyValueStore: keyValueStore)
     }
     
-    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayURL: URL, logger: BaseLogger = MuteLogger(), keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage) {
+    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, logger: BaseLogger = MuteLogger(), keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage) {
         self.metadata = metadata
         self.isController = isController
 //        try? keychain.deleteAll() // Use for cleanup while lifecycles are not handled yet, but FIXME whenever
         self.crypto = Crypto(keychain: keychain)
-        let wakuRelay = WakuNetworkRelay(transport: JSONRPCTransport(url: relayURL), logger: logger)
+        let relayUrl = Self.makeRelayUrl(host: relayHost, apiKey: apiKey)
+        let wakuRelay = WakuNetworkRelay(transport: JSONRPCTransport(url: relayUrl), logger: logger)
         let serialiser = JSONRPCSerialiser(crypto: crypto)
         self.relay = WalletConnectRelay(networkRelayer: wakuRelay, jsonRpcSerialiser: serialiser, logger: logger, jsonRpcHistory: JsonRpcHistory(logger: logger, keyValueStorage: keyValueStore))
         let sessionSequencesStore = SessionUserDefaultsStore(logger: logger)
@@ -213,6 +213,14 @@ public final class WalletConnectClient {
             proposal: proposal
         )
         delegate?.didReceive(sessionProposal: sessionProposal)
+    }
+    
+    private static func makeRelayUrl(host: String, apiKey: String) -> URL {
+        var components = URLComponents()
+        components.scheme = "wss"
+        components.host = host
+        components.queryItems = [URLQueryItem(name: "apiKey", value: apiKey)]
+        return components.url!
     }
 }
 

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -38,7 +38,7 @@ public final class WalletConnectClient {
         self.isController = isController
 //        try? keychain.deleteAll() // Use for cleanup while lifecycles are not handled yet, but FIXME whenever
         self.crypto = Crypto(keychain: keychain)
-        let relayUrl = Self.makeRelayUrl(host: relayHost, apiKey: apiKey)
+        let relayUrl = WakuNetworkRelay.makeRelayUrl(host: relayHost, apiKey: apiKey)
         let wakuRelay = WakuNetworkRelay(transport: JSONRPCTransport(url: relayUrl), logger: logger)
         let serialiser = JSONRPCSerialiser(crypto: crypto)
         self.relay = WalletConnectRelay(networkRelayer: wakuRelay, jsonRpcSerialiser: serialiser, logger: logger, jsonRpcHistory: JsonRpcHistory(logger: logger, keyValueStorage: keyValueStore))
@@ -213,14 +213,6 @@ public final class WalletConnectClient {
             proposal: proposal
         )
         delegate?.didReceive(sessionProposal: sessionProposal)
-    }
-    
-    private static func makeRelayUrl(host: String, apiKey: String) -> URL {
-        var components = URLComponents()
-        components.scheme = "wss"
-        components.host = host
-        components.queryItems = [URLQueryItem(name: "apiKey", value: apiKey)]
-        return components.url!
     }
 }
 

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -30,10 +30,10 @@ public final class WalletConnectClient {
     // MARK: - Public interface
 
     public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, keyValueStore: KeyValueStorage = UserDefaults.standard) {
-        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayHost: relayHost, keyValueStore: keyValueStore)
+        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayHost: relayHost, logger: ConsoleLogger(loggingLevel: .off), keyValueStore: keyValueStore)
     }
     
-    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, logger: ConsoleLogger = ConsoleLogger(loggingLevel: .off), keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage) {
+    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, logger: ConsoleLogger, keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage) {
         self.metadata = metadata
         self.isController = isController
         self.logger = logger

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -29,8 +29,8 @@ public final class WalletConnectClient {
     
     // MARK: - Public interface
 
-    public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayURL: URL, keyValueStore: KeyValueStorage = UserDefaults.standard) {
-        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayURL: relayURL, logger: MuteLogger(), keyValueStore: keyValueStore)
+    public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, keyValueStore: KeyValueStorage = UserDefaults.standard) {
+        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayHost: relayHost, logger: MuteLogger(), keyValueStore: keyValueStore)
     }
     
     init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, logger: BaseLogger = MuteLogger(), keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage) {

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -7,22 +7,23 @@ final class ClientTests: XCTestCase {
     
     let defaultTimeout: TimeInterval = 5.0
     
-    let url = URL(string: "wss://staging.walletconnect.org")! // TODO: Change to new URL
+    let relayHost = "relay.walletconnect.org"
+    let apiKey = ""
     var proposer: ClientDelegate!
     var responder: ClientDelegate!
     
     override func setUp() {
-        proposer = Self.makeClientDelegate(isController: false, url: url, prefix: "🍏P")
-        responder = Self.makeClientDelegate(isController: true, url: url, prefix: "🍎R")
+        proposer = Self.makeClientDelegate(isController: false, relayHost: relayHost, prefix: "🍏P", apiKey: apiKey)
+        responder = Self.makeClientDelegate(isController: true, relayHost: relayHost, prefix: "🍎R", apiKey: apiKey)
     }
 
-    static func makeClientDelegate(isController: Bool, url: URL, prefix: String) -> ClientDelegate {
+    static func makeClientDelegate(isController: Bool, relayHost: String, prefix: String, apiKey: String) -> ClientDelegate {
         let logger = ConsoleLogger(suffix: prefix)
         let client = WalletConnectClient(
             metadata: AppMetadata(name: nil, description: nil, url: nil, icons: nil),
-            apiKey: "",
+            apiKey: apiKey,
             isController: isController,
-            relayURL: url,
+            relayHost: relayHost,
             logger: logger,
             keychain: KeychainStorage(keychainService: KeychainServiceFake()), keyValueStore: RuntimeKeyValueStorage())
         client.sessionEngine.sequencesStore = SessionDictionaryStore(logger: logger)

--- a/Tests/WalletConnectTests/JsonRpcHistoryTests.swift
+++ b/Tests/WalletConnectTests/JsonRpcHistoryTests.swift
@@ -10,7 +10,7 @@ final class JsonRpcHistoryTests: XCTestCase {
     var sut: JsonRpcHistory!
             
     override func setUp() {
-        sut = JsonRpcHistory(logger: MuteLogger(), keyValueStorage: RuntimeKeyValueStorage())
+        sut = JsonRpcHistory(logger: ConsoleLogger(), keyValueStorage: RuntimeKeyValueStorage())
     }
     
     override func tearDown() {

--- a/Tests/WalletConnectTests/PairingEnginTests.swift
+++ b/Tests/WalletConnectTests/PairingEnginTests.swift
@@ -15,7 +15,7 @@ class PairingEngineTests: XCTestCase {
         relay = MockedWCRelay()
         subscriber = MockedSubscriber()
         let meta = AppMetadata(name: nil, description: nil, url: nil, icons: nil)
-        let logger = MuteLogger()
+        let logger = ConsoleLogger()
         let store = SequenceStore<PairingSequence>(storage: RuntimeKeyValueStorage())
         engine = PairingEngine(relay: relay, crypto: crypto, subscriber: subscriber, sequencesStore: store, isController: false, metadata: meta, logger: logger)
     }

--- a/Tests/WalletConnectTests/SessionEngineTests.swift
+++ b/Tests/WalletConnectTests/SessionEngineTests.swift
@@ -14,7 +14,7 @@ class SessionEngineTests: XCTestCase {
         relay = MockedWCRelay()
         subscriber = MockedSubscriber()
         let meta = AppMetadata(name: nil, description: nil, url: nil, icons: nil)
-        let logger = MuteLogger()
+        let logger = ConsoleLogger()
         engine = SessionEngine(relay: relay, crypto: crypto, subscriber: subscriber, sequencesStore: SessionDictionaryStore(logger: logger), isController: false, metadata: meta, logger: logger)
     }
 

--- a/Tests/WalletConnectTests/SubscriptionTest.swift
+++ b/Tests/WalletConnectTests/SubscriptionTest.swift
@@ -9,7 +9,7 @@ class WCSubscriberTest: XCTestCase {
     var subscriber: WCSubscriber!
     override func setUp() {
         relay = MockedWCRelay()
-        subscriber = WCSubscriber(relay: relay, logger: MuteLogger())
+        subscriber = WCSubscriber(relay: relay, logger: ConsoleLogger())
     }
 
     override func tearDown() {

--- a/Tests/WalletConnectTests/WakuRelayTests.swift
+++ b/Tests/WalletConnectTests/WakuRelayTests.swift
@@ -11,7 +11,7 @@ class WakuRelayTests: XCTestCase {
 
     override func setUp() {
         transport = MockedJSONRPCTransport()
-        let logger = MuteLogger()
+        let logger = ConsoleLogger()
         wakuRelay = WakuNetworkRelay(transport: transport, logger: logger)
     }
 


### PR DESCRIPTION
Handles non wallet connect methods with warnings.
Updates console logger and add `warn` and `info` log levels. Log levels can be set by client consumer.
close #126 