### PR TITLE
#public interface

### DIFF
--- a/Example/ExampleApp.xcodeproj/project.pbxproj
+++ b/Example/ExampleApp.xcodeproj/project.pbxproj
@@ -354,12 +354,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ExampleApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.walletconnect.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -373,12 +376,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ExampleApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.walletconnect.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/Example/ExampleApp/Info.plist
+++ b/Example/ExampleApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/Example/ExampleApp/Proposer/ProposerViewController.swift
+++ b/Example/ExampleApp/Proposer/ProposerViewController.swift
@@ -181,7 +181,7 @@ extension ProposerViewController: WalletConnectClientDelegate {
         }
     }
     
-    func didReject(sessionPendingTopic: String, reason: SessionType.Reason) {
+    func didReject(pendingSessionTopic: String, reason: SessionType.Reason) {
         print("[PROPOSER] WC: Did reject session")
     }
 }

--- a/Example/ExampleApp/Responder/ActiveSessionItem.swift
+++ b/Example/ExampleApp/Responder/ActiveSessionItem.swift
@@ -4,37 +4,3 @@ struct ActiveSessionItem {
     let iconURL: String
     let topic: String
 }
-
-extension ActiveSessionItem {
-    
-    static func mockList() -> [ActiveSessionItem] {
-        [mockPancakeSwap(), mockUniswap(), mockSushiSwap()]
-    }
-    
-    static func mockPancakeSwap() -> ActiveSessionItem {
-        ActiveSessionItem(
-            dappName: "PancakeSwap",
-            dappURL: "pancakeswap.finance",
-            iconURL: "https://pancakeswap.finance/logo.png",
-            topic: ""
-        )
-    }
-    
-    static func mockUniswap() -> ActiveSessionItem {
-        ActiveSessionItem(
-            dappName: "Uniswap",
-            dappURL: "app.uniswap.org",
-            iconURL: "https://s2.coinmarketcap.com/static/img/coins/64x64/7083.png",
-            topic: ""
-        )
-    }
-    
-    static func mockSushiSwap() -> ActiveSessionItem {
-        ActiveSessionItem(
-            dappName: "Sushi Swap",
-            dappURL: "app.sushi.com",
-            iconURL: "https://s2.coinmarketcap.com/static/img/coins/64x64/6758.png",
-            topic: ""
-        )
-    }
-}

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -118,7 +118,8 @@ extension ResponderViewController: SessionViewControllerDelegate {
         print("[RESPONDER] Approving session...")
         let proposal = currentProposal!
         currentProposal = nil
-        client.approve(proposal: proposal, accounts: [])
+        client.approve(proposal: proposal, accounts: []) { _ in
+        }
     }
     
     func didRejectSession() {
@@ -196,7 +197,7 @@ extension ResponderViewController: WalletConnectClientDelegate {
         print("[RESPONDER] WC: Did settle pairing")
     }
     
-    func didReject(sessionPendingTopic: String, reason: SessionType.Reason) {
+    func didReject(pendingSessionTopic: String, reason: SessionType.Reason) {
         print("[RESPONDER] WC: Did reject session")
     }
 }

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -37,8 +37,8 @@ final class ResponderViewController: UIViewController {
         
         responderView.tableView.dataSource = self
         responderView.tableView.delegate = self
-        sessionItems = ActiveSessionItem.mockList()
-        
+        let settledSessions = client.getSettledSessions()
+        sessionItems = getActiveSessionItem(for: settledSessions)
         client.delegate = self
     }
     
@@ -179,17 +179,21 @@ extension ResponderViewController: WalletConnectClientDelegate {
     func didSettle(session: Session) {
         print("[RESPONDER] WC: Did settle session")
         let settledSessions = client.getSettledSessions()
-        let activeSessions = settledSessions.map { session -> ActiveSessionItem in
+        let activeSessions = getActiveSessionItem(for: settledSessions)
+        DispatchQueue.main.async { // FIXME: Delegate being called from background thread
+            self.sessionItems = activeSessions
+            self.responderView.tableView.reloadData()
+        }
+    }
+    
+    private func getActiveSessionItem(for settledSessions: [Session]) -> [ActiveSessionItem] {
+        return settledSessions.map { session -> ActiveSessionItem in
             let app = session.peer
             return ActiveSessionItem(
                 dappName: app.name ?? "",
                 dappURL: app.url ?? "",
                 iconURL: app.icons?.first ?? "",
                 topic: session.topic)
-        }
-        DispatchQueue.main.async { // FIXME: Delegate being called from background thread
-            self.sessionItems = activeSessions
-            self.responderView.tableView.reloadData()
         }
     }
     

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -213,12 +213,12 @@ final class SessionEngine {
         }
     }
     
-    func respondSessionPayload(topic: String, response: JSONRPCResponse<AnyCodable>) {
+    func respondSessionPayload(topic: String, response: JsonRpcResponseTypes) {
         guard sequencesStore.hasSequence(forTopic: topic) else {
             logger.debug("Could not find session for topic \(topic)")
             return
         }
-        relayer.respond(topic: topic, response: JsonRpcResponseTypes.response(response)) { [weak self] error in
+        relayer.respond(topic: topic, response: response) { [weak self] error in
             if let error = error {
                 self?.logger.debug("Could not send session payload, error: \(error.localizedDescription)")
             } else {

--- a/Sources/WalletConnect/JSONRPC/JSONRPCErrorResponse.swift
+++ b/Sources/WalletConnect/JSONRPC/JSONRPCErrorResponse.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-struct JSONRPCErrorResponse: Error, Equatable, Codable {
+public struct JSONRPCErrorResponse: Error, Equatable, Codable {
     public let jsonrpc = "2.0"
     public let id: Int64
     public let error: JSONRPCErrorResponse.Error
@@ -16,7 +16,7 @@ struct JSONRPCErrorResponse: Error, Equatable, Codable {
         self.id = id
         self.error = error
     }
-    struct Error: Codable, Equatable {
+    public struct Error: Codable, Equatable {
         let code: Int
         let message: String
     }

--- a/Sources/WalletConnect/JsonRpcHistory/JsonRpcHistory.swift
+++ b/Sources/WalletConnect/JsonRpcHistory/JsonRpcHistory.swift
@@ -12,10 +12,12 @@ protocol JsonRpcHistoryRecording {
 class JsonRpcHistory: JsonRpcHistoryRecording {
     let storage: KeyValueStore<JsonRpcRecord>
     let logger: ConsoleLogger
+    let clientName: String
     
-    init(logger: ConsoleLogger, keyValueStorage: KeyValueStorage) {
+    init(logger: ConsoleLogger, keyValueStorage: KeyValueStorage, clientName: String?) {
         self.logger = logger
         self.storage = KeyValueStore<JsonRpcRecord>(defaults: keyValueStorage)
+        self.clientName = clientName ?? ""
     }
     
     func get(id: Int64) -> JsonRpcRecord? {
@@ -54,6 +56,7 @@ class JsonRpcHistory: JsonRpcHistoryRecording {
     }
     
     private func getKey(for id: Int64) -> String {
-        return "wc_json_rpc_record_\(id)"
+        let prefix = "\(clientName)_wc_json_rpc_record_"
+        return "\(prefix)\(id)"
     }
 }

--- a/Sources/WalletConnect/Relay/WalletConnectRelay.swift
+++ b/Sources/WalletConnect/Relay/WalletConnectRelay.swift
@@ -11,7 +11,7 @@ protocol WalletConnectRelaying {
     func unsubscribe(topic: String)
 }
 
-enum JsonRpcResponseTypes: Codable {
+public enum JsonRpcResponseTypes: Codable {
     case error(JSONRPCErrorResponse)
     case response(JSONRPCResponse<AnyCodable>)
     var id: Int64 {

--- a/Sources/WalletConnect/Storage/SequenceStore.swift
+++ b/Sources/WalletConnect/Storage/SequenceStore.swift
@@ -14,10 +14,12 @@ final class SequenceStore<T> where T: ExpirableSequence {
     
     private let storage: KeyValueStorage
     private let dateInitializer: () -> Date
+    private let keyPrefix: String
 
-    init(storage: KeyValueStorage, dateInitializer: @escaping () -> Date = Date.init) {
+    init(storage: KeyValueStorage, keyPrefix: String? = nil, dateInitializer: @escaping () -> Date = Date.init) {
         self.storage = storage
         self.dateInitializer = dateInitializer
+        self.keyPrefix = keyPrefix ?? ""
     }
     
     func hasSequence(forTopic topic: String) -> Bool {
@@ -61,5 +63,9 @@ final class SequenceStore<T> where T: ExpirableSequence {
             return nil
         }
         return sequence
+    }
+    
+    private func getKey(for topic: String) -> String {
+        return "\(keyPrefix)_\(topic)"
     }
 }

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -8,11 +8,11 @@ public protocol WalletConnectClientDelegate: AnyObject {
     func didDelete(sessionTopic: String, reason: SessionType.Reason)
     func didUpgrade(sessionTopic: String, permissions: SessionType.Permissions)
     func didUpdate(sessionTopic: String, accounts: Set<String>)
-    func didSettle(session: Session) //Optional
-    func didSettle(pairing: Pairing) //Optional
-    func didReceive(notification: SessionNotification, sessionTopic: String) //Optional
-    func didReject(pendingSessionTopic: String, reason: SessionType.Reason) //Optional
-    func didUpdate(pairingTopic: String, appMetadata: AppMetadata) //Optional
+    func didSettle(session: Session)
+    func didSettle(pairing: Pairing)
+    func didReceive(notification: SessionNotification, sessionTopic: String)
+    func didReject(pendingSessionTopic: String, reason: SessionType.Reason)
+    func didUpdate(pairingTopic: String, appMetadata: AppMetadata)
 }
 
 extension WalletConnectClientDelegate {
@@ -51,7 +51,7 @@ public final class WalletConnectClient {
         let wakuRelay = WakuNetworkRelay(transport: JSONRPCTransport(url: relayUrl), logger: logger)
         let serialiser = JSONRPCSerialiser(crypto: crypto)
         let sessionSequencesStore = SequenceStore<SessionSequence>(storage: keyValueStore)
-        self.relay = WalletConnectRelay(networkRelayer: wakuRelay, jsonRpcSerialiser: serialiser, logger: logger, jsonRpcHistory: JsonRpcHistory(logger: logger, keyValueStorage: keyValueStore))
+        self.relay = WalletConnectRelay(networkRelayer: wakuRelay, jsonRpcSerialiser: serialiser, logger: logger, jsonRpcHistory: JsonRpcHistory(logger: logger, keyValueStorage: keyValueStore, clientName: clientName))
         let pairingSequencesStore = SequenceStore<PairingSequence>(storage: keyValueStore, keyPrefix: clientName)
         self.pairingEngine = PairingEngine(relay: relay, crypto: crypto, subscriber: WCSubscriber(relay: relay, logger: logger), sequencesStore: pairingSequencesStore, isController: isController, metadata: metadata, logger: logger)
         self.sessionEngine = SessionEngine(relay: relay, crypto: crypto, subscriber: WCSubscriber(relay: relay, logger: logger), sequencesStore: sessionSequencesStore, isController: isController, metadata: metadata, logger: logger)

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -37,8 +37,8 @@ public final class WalletConnectClient {
     
     // MARK: - Public interface
 
-    public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, keyValueStore: KeyValueStorage = UserDefaults.standard, clientName: String? = nil) {
-        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayHost: relayHost, logger: ConsoleLogger(loggingLevel: .off), keyValueStore: keyValueStore, clientName: clientName)
+    public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, keyValueStorage: KeyValueStorage = UserDefaults.standard, clientName: String? = nil) {
+        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayHost: relayHost, logger: ConsoleLogger(loggingLevel: .off), keyValueStore: keyValueStorage, clientName: clientName)
     }
     
     init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, logger: ConsoleLogger, keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage, clientName: String? = nil) {

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -37,11 +37,11 @@ public final class WalletConnectClient {
     
     // MARK: - Public interface
 
-    public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, keyValueStore: KeyValueStorage = UserDefaults.standard) {
-        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayHost: relayHost, logger: ConsoleLogger(loggingLevel: .off), keyValueStore: keyValueStore)
+    public convenience init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, keyValueStore: KeyValueStorage = UserDefaults.standard, clientName: String? = nil) {
+        self.init(metadata: metadata, apiKey: apiKey, isController: isController, relayHost: relayHost, logger: ConsoleLogger(loggingLevel: .off), keyValueStore: keyValueStore, clientName: clientName)
     }
     
-    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, logger: ConsoleLogger, keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage) {
+    init(metadata: AppMetadata, apiKey: String, isController: Bool, relayHost: String, logger: ConsoleLogger, keychain: KeychainStorage = KeychainStorage(), keyValueStore: KeyValueStorage, clientName: String? = nil) {
         self.metadata = metadata
         self.isController = isController
         self.logger = logger
@@ -52,7 +52,7 @@ public final class WalletConnectClient {
         let serialiser = JSONRPCSerialiser(crypto: crypto)
         let sessionSequencesStore = SequenceStore<SessionSequence>(storage: keyValueStore)
         self.relay = WalletConnectRelay(networkRelayer: wakuRelay, jsonRpcSerialiser: serialiser, logger: logger, jsonRpcHistory: JsonRpcHistory(logger: logger, keyValueStorage: keyValueStore))
-        let pairingSequencesStore = SequenceStore<PairingSequence>(storage: keyValueStore)
+        let pairingSequencesStore = SequenceStore<PairingSequence>(storage: keyValueStore, keyPrefix: clientName)
         self.pairingEngine = PairingEngine(relay: relay, crypto: crypto, subscriber: WCSubscriber(relay: relay, logger: logger), sequencesStore: pairingSequencesStore, isController: isController, metadata: metadata, logger: logger)
         self.sessionEngine = SessionEngine(relay: relay, crypto: crypto, subscriber: WCSubscriber(relay: relay, logger: logger), sequencesStore: sessionSequencesStore, isController: isController, metadata: metadata, logger: logger)
         setUpEnginesCallbacks()

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -50,7 +50,7 @@ public final class WalletConnectClient {
         let relayUrl = WakuNetworkRelay.makeRelayUrl(host: relayHost, apiKey: apiKey)
         let wakuRelay = WakuNetworkRelay(transport: JSONRPCTransport(url: relayUrl), logger: logger)
         let serialiser = JSONRPCSerialiser(crypto: crypto)
-        let sessionSequencesStore = SequenceStore<SessionSequence>(storage: keyValueStore)
+        let sessionSequencesStore = SequenceStore<SessionSequence>(storage: keyValueStore, keyPrefix: clientName)
         self.relay = WalletConnectRelay(networkRelayer: wakuRelay, jsonRpcSerialiser: serialiser, logger: logger, jsonRpcHistory: JsonRpcHistory(logger: logger, keyValueStorage: keyValueStore, clientName: clientName))
         let pairingSequencesStore = SequenceStore<PairingSequence>(storage: keyValueStore, keyPrefix: clientName)
         self.pairingEngine = PairingEngine(relay: relay, crypto: crypto, subscriber: WCSubscriber(relay: relay, logger: logger), sequencesStore: pairingSequencesStore, isController: isController, metadata: metadata, logger: logger)

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -135,7 +135,7 @@ public final class WalletConnectClient {
     }
     
     // for responder to respond JSON-RPC
-    public func respond(topic: String, response: JSONRPCResponse<AnyCodable>) {
+    public func respond(topic: String, response: JsonRpcResponseTypes) {
         sessionEngine.respondSessionPayload(topic: topic, response: response)
     }
     

--- a/Tests/IntegrationTests/ClientDelegate.swift
+++ b/Tests/IntegrationTests/ClientDelegate.swift
@@ -20,8 +20,8 @@ class ClientDelegate: WalletConnectClientDelegate {
         client.delegate = self
     }
     
-    func didReject(sessionPendingTopic: String, reason: SessionType.Reason) {
-        onSessionRejected?(sessionPendingTopic, reason)
+    func didReject(pendingSessionTopic: String, reason: SessionType.Reason) {
+        onSessionRejected?(pendingSessionTopic, reason)
     }
     func didSettle(session: Session) {
         onSessionSettled?(session)

--- a/Tests/IntegrationTests/ClientTest.swift
+++ b/Tests/IntegrationTests/ClientTest.swift
@@ -7,7 +7,7 @@ final class ClientTests: XCTestCase {
     
     let defaultTimeout: TimeInterval = 5.0
     
-    let relayHost = "relay.walletconnect.org"
+    let relayHost = "staging.walletconnect.org"
     let apiKey = ""
     var proposer: ClientDelegate!
     var responder: ClientDelegate!

--- a/Tests/WalletConnectTests/JsonRpcHistoryTests.swift
+++ b/Tests/WalletConnectTests/JsonRpcHistoryTests.swift
@@ -10,7 +10,7 @@ final class JsonRpcHistoryTests: XCTestCase {
     var sut: JsonRpcHistory!
             
     override func setUp() {
-        sut = JsonRpcHistory(logger: ConsoleLogger(), keyValueStorage: RuntimeKeyValueStorage())
+        sut = JsonRpcHistory(logger: ConsoleLogger(), keyValueStorage: RuntimeKeyValueStorage(), clientName: nil)
     }
     
     override func tearDown() {

--- a/Tests/WalletConnectTests/WCRelayTests.swift
+++ b/Tests/WalletConnectTests/WCRelayTests.swift
@@ -16,7 +16,7 @@ class WalletConnectRelayTests: XCTestCase {
         let logger = ConsoleLogger()
         serialiser = MockedJSONRPCSerialiser()
         networkRelayer = MockedNetworkRelayer()
-        wcRelay = WalletConnectRelay(networkRelayer: networkRelayer, jsonRpcSerialiser: serialiser, logger: logger, jsonRpcHistory: JsonRpcHistory(logger: logger, keyValueStorage: RuntimeKeyValueStorage()))
+        wcRelay = WalletConnectRelay(networkRelayer: networkRelayer, jsonRpcSerialiser: serialiser, logger: logger, jsonRpcHistory: JsonRpcHistory(logger: logger, keyValueStorage: RuntimeKeyValueStorage(), clientName: nil))
     }
 
     override func tearDown() {


### PR DESCRIPTION
contains several improvements to public interface:

- add property to name a client in order to allow multiple client instances that shares storage to live on one device.
- prefix keys for keyValue store with client name in json rpc history kv store and pairing sequence
- make proposer related delegate methods optional
- add completion with session to `approve()` method
- allow to respond with error type on `session_payload`

it also provides a change to sample app:
- displays a settled sessions instead of mocked content on a responder screen after app is launched 