### PR TITLE
Remove ConnectParams from pair proposal call

### DIFF
--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -123,7 +123,7 @@ final class PairingEngine {
         }
     }
     
-    func propose(_ params: ConnectParams) -> PairingType.Pending? {
+    func propose() -> PairingType.Pending? {
         logger.debug("Propose Pairing")
         guard let topic = String.generateTopic() else {
             logger.debug("Could not generate topic")

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -63,7 +63,7 @@ public final class WalletConnectClient {
             sessionEngine.proposeSession(settledPairing: Pairing(topic: pairing.topic, peer: nil), permissions: params.permissions, relay: pairing.relay)
             return nil
         } else {
-            guard let pending = pairingEngine.propose(params) else {
+            guard let pending = pairingEngine.propose() else {
                 throw WalletConnectError.internal(.pairingProposalGenerationFailed)
             }
             sessionPermissions[pending.topic] = params.permissions


### PR DESCRIPTION
Removes unnecessary `ConnectParams` from pairing engine `promose(_:)` call.