### PR TITLE
#181 prevent approving same paring multiple times

### DIFF
--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -32,7 +32,6 @@ final class ResponderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = "Wallet"
-        client.logger.setLogging(level: .debug)
         responderView.scanButton.addTarget(self, action: #selector(showScanner), for: .touchUpInside)
         responderView.pasteButton.addTarget(self, action: #selector(showTextInput), for: .touchUpInside)
         
@@ -137,9 +136,7 @@ extension ResponderViewController: UITableViewDataSource, UITableViewDelegate {
 extension ResponderViewController: ScannerViewControllerDelegate {
     
     func didScan(_ code: String) {
-        DispatchQueue.global().async { [weak self] in
-            self?.pairClient(uri: code)
-        }
+        pairClient(uri: code)
     }
 }
 

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -32,7 +32,7 @@ final class ResponderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = "Wallet"
-        
+        client.logger.setLogging(level: .info)
         responderView.scanButton.addTarget(self, action: #selector(showScanner), for: .touchUpInside)
         responderView.pasteButton.addTarget(self, action: #selector(showTextInput), for: .touchUpInside)
         
@@ -137,7 +137,9 @@ extension ResponderViewController: UITableViewDataSource, UITableViewDelegate {
 extension ResponderViewController: ScannerViewControllerDelegate {
     
     func didScan(_ code: String) {
-        pairClient(uri: code)
+        DispatchQueue.global().async { [weak self] in
+            self?.pairClient(uri: code)
+        }
     }
 }
 

--- a/Example/ExampleApp/Responder/ResponderViewController.swift
+++ b/Example/ExampleApp/Responder/ResponderViewController.swift
@@ -32,7 +32,7 @@ final class ResponderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = "Wallet"
-        client.logger.setLogging(level: .info)
+        client.logger.setLogging(level: .debug)
         responderView.scanButton.addTarget(self, action: #selector(showScanner), for: .touchUpInside)
         responderView.pasteButton.addTarget(self, action: #selector(showTextInput), for: .touchUpInside)
         

--- a/Sources/WalletConnect/Engine/PairingEngine.swift
+++ b/Sources/WalletConnect/Engine/PairingEngine.swift
@@ -78,7 +78,7 @@ final class PairingEngine {
             settledState: settled)
         
         wcSubscriber.setSubscription(topic: settledTopic)
-        try? sequencesStore.update(sequence: settledPairing, onTopic: proposal.topic)
+        try? sequencesStore.setSequence(settledPairing)
         
         crypto.set(agreementKeys: agreementKeys, topic: settledTopic)
         crypto.set(privateKey: privateKey)

--- a/Sources/WalletConnect/Engine/SessionEngine.swift
+++ b/Sources/WalletConnect/Engine/SessionEngine.swift
@@ -480,10 +480,13 @@ final class SessionEngine {
     
     private func handleSessionApprove(_ approveParams: SessionType.ApproveParams, topic: String, requestId: Int64) {
         logger.debug("Responder Client approved session on topic: \(topic)")
-        guard let session = try? sequencesStore.getSequence(forTopic: topic), let pendingSession = session.pending else {
-            logger.error("Could not find pending session for topic: \(topic)")
-            return
-        }
+        logger.debug("isController: \(isController)")
+        guard !isController,
+              let session = try? sequencesStore.getSequence(forTopic: topic),
+              let pendingSession = session.pending else {
+                  logger.error("Could not find pending session for topic: \(topic)")
+                  return
+              }
         
         let selfPublicKey = Data(hex: session.selfParticipant.publicKey)
         logger.debug("handleSessionApprove")

--- a/Sources/WalletConnect/Relay/NetworkRelaying.swift
+++ b/Sources/WalletConnect/Relay/NetworkRelaying.swift
@@ -17,7 +17,7 @@ class WakuNetworkRelay: NetworkRelaying {
     private typealias SubscriptionRequest = JSONRPCRequest<RelayJSONRPC.SubscriptionParams>
     private typealias SubscriptionResponse = JSONRPCResponse<String>
     private typealias RequestAcknowledgement = JSONRPCResponse<Bool>
-    private let concurrentQueue = DispatchQueue(label: "waku relay queue: \(UUID().uuidString)",
+    private let concurrentQueue = DispatchQueue(label: "com.walletconnect.sdk.waku.relay",
                                                 attributes: .concurrent)
     var onConnect: (() -> ())?
     

--- a/Sources/WalletConnect/Storage/SequenceStore.swift
+++ b/Sources/WalletConnect/Storage/SequenceStore.swift
@@ -46,11 +46,6 @@ final class SequenceStore<T> where T: ExpirableSequence {
         }
     }
 
-    func update(sequence: T) throws {
-        storage.removeObject(forKey: getKey(for: sequence.topic))
-        try setSequence(sequence)
-    }
-    
     //TODO - to be removed after session engine refactor
     func update(sequence: T, onTopic topic: String) throws {
         storage.removeObject(forKey: getKey(for: topic))

--- a/Sources/WalletConnect/Storage/SequenceStore.swift
+++ b/Sources/WalletConnect/Storage/SequenceStore.swift
@@ -46,11 +46,16 @@ final class SequenceStore<T> where T: ExpirableSequence {
         }
     }
 
+    func update(sequence: T) throws {
+        storage.removeObject(forKey: getKey(for: sequence.topic))
+        try setSequence(sequence)
+    }
+    
+    //TODO - to be removed after session engine refactor
     func update(sequence: T, onTopic topic: String) throws {
         storage.removeObject(forKey: getKey(for: topic))
         try setSequence(sequence)
     }
-
     func delete(topic: String) {
         storage.removeObject(forKey: getKey(for: topic))
     }

--- a/Sources/WalletConnect/Subscription/WCSubscribing.swift
+++ b/Sources/WalletConnect/Subscription/WCSubscribing.swift
@@ -11,7 +11,7 @@ protocol WCSubscribing: AnyObject {
 class WCSubscriber: WCSubscribing {
     private var relay: WalletConnectRelaying
     var onRequestSubscription: ((WCRequestSubscriptionPayload)->())?
-    private let concurrentQueue = DispatchQueue(label: "wc subscriber queue: \(UUID().uuidString)",
+    private let concurrentQueue = DispatchQueue(label: "com.walletconnect.sdk.wc_subscriber",
                                                 attributes: .concurrent)
     private var publishers = [AnyCancellable]()
     private let logger: ConsoleLogger

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 struct PairingSequence: ExpirableSequence {
-    
     let topic: String
     let relay: RelayProtocolOptions
     let selfParticipant: PairingType.Participant
@@ -50,16 +49,16 @@ extension PairingSequence {
     }
 }
     
-extension PairingSequence {
-    
+extension PairingSequence {    
     struct Pending: Codable {
         let proposal: PairingType.Proposal
-        let status: PairingType.Pending.PendingStatus
+        var status: PairingType.Pending.PendingStatus
     }
 
     struct Settled: Codable {
         let peer: PairingType.Participant
         let permissions: PairingType.Permissions
         var state: PairingType.State?
+        var status: PairingType.Settled.SettledStatus
     }
 }

--- a/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSequence.swift
@@ -52,13 +52,13 @@ extension PairingSequence {
 extension PairingSequence {    
     struct Pending: Codable {
         let proposal: PairingType.Proposal
-        var status: PairingType.Pending.PendingStatus
+        let status: PairingType.Pending.PendingStatus
     }
 
     struct Settled: Codable {
         let peer: PairingType.Participant
         let permissions: PairingType.Permissions
         var state: PairingType.State?
-        var status: PairingType.Settled.SettledStatus
+        let status: PairingType.Settled.SettledStatus
     }
 }

--- a/Sources/WalletConnect/Types/Pairing/PairingSettled.swift
+++ b/Sources/WalletConnect/Types/Pairing/PairingSettled.swift
@@ -3,6 +3,10 @@ import Foundation
 
 extension PairingType {
     public struct Settled: Codable, SequenceSettled, Equatable {
+        enum SettledStatus: String, Equatable, Codable {
+            case preSettled = "preSettled"
+            case acknowledged = "acknowledged"
+        }
         public let topic: String
         let relay: RelayProtocolOptions
         let `self`: Participant

--- a/Sources/WalletConnect/WalletConnectClient.swift
+++ b/Sources/WalletConnect/WalletConnectClient.swift
@@ -37,6 +37,8 @@ public final class WalletConnectClient {
     public let logger: ConsoleLogger
     private let transport: JSONRPCTransport
     private let secureStorage: SecureStorage
+    private let pairingQueue = DispatchQueue(label: "com.walletconnect.sdk.client.pairing", qos: .userInitiated)
+
     
     // MARK: - Public interface
 
@@ -91,22 +93,26 @@ public final class WalletConnectClient {
     
     // for responder to receive a session proposal from a proposer
     public func pair(uri: String) throws {
-        print("start pair")
-        guard let pairingURI = WalletConnectURI(string: uri) else {
-            throw WalletConnectError.internal(.malformedPairingURI)
-        }
-        let proposal = PairingType.Proposal.createFromURI(pairingURI)
-        let approved = proposal.proposer.controller != isController
-        if !approved {
-            throw WalletConnectError.internal(.unauthorizedMatchingController)
-        }
-        pairingEngine.approve(proposal) { [unowned self] result in
-            switch result {
-            case .success(let settledPairing):
-                logger.debug("Pairing Success")
-                self.delegate?.didSettle(pairing: settledPairing)
-            case .failure(let error):
-                print("Pairing Failure: \(error)")
+        try pairingQueue.sync {
+            guard let pairingURI = WalletConnectURI(string: uri) else {
+                throw WalletConnectError.internal(.malformedPairingURI)
+            }
+            let proposal = PairingType.Proposal.createFromURI(pairingURI)
+            let approved = proposal.proposer.controller != isController
+            guard approved else {
+                throw WalletConnectError.internal(.unauthorizedMatchingController)
+            }
+            guard !pairingEngine.sequencesStore.hasSequence(forTopic: proposal.topic) else {
+                throw WalletConnectError.internal(.pairWithExistingPairingForbidden)
+            }
+            pairingEngine.approve(proposal) { [unowned self] result in
+                switch result {
+                case .success(let settledPairing):
+                    logger.debug("Pairing Success")
+                    self.delegate?.didSettle(pairing: settledPairing)
+                case .failure(let error):
+                    print("Pairing Failure: \(error)")
+                }
             }
         }
     }

--- a/Sources/WalletConnect/WalletConnectError.swift
+++ b/Sources/WalletConnect/WalletConnectError.swift
@@ -25,6 +25,7 @@ enum WalletConnectError: Error {
         case keyNotFound
         case deserialisationFailed
         case jsonRpcDuplicateDetected
+        case pairWithExistingPairingForbidden
     }
     
     public enum UnauthorizedReason: Error {
@@ -75,6 +76,7 @@ extension WalletConnectError.InternalReason: CustomStringConvertible {
         case .keyNotFound: return 00
         case .deserialisationFailed: return 00
         case .jsonRpcDuplicateDetected: return 0
+        case .pairWithExistingPairingForbidden: return 0
         }
     }
     
@@ -99,6 +101,8 @@ extension WalletConnectError.InternalReason: CustomStringConvertible {
             return "Deserialisation Failed"
         case .jsonRpcDuplicateDetected:
             return "Json Rpc Duplicate Detected"
+        case .pairWithExistingPairingForbidden:
+            return "Pair With Existing Pairing Is Forbidden"
         }
     }
 }

--- a/Sources/WalletConnect/WalletConnectError.swift
+++ b/Sources/WalletConnect/WalletConnectError.swift
@@ -102,7 +102,7 @@ extension WalletConnectError.InternalReason: CustomStringConvertible {
         case .jsonRpcDuplicateDetected:
             return "Json Rpc Duplicate Detected"
         case .pairWithExistingPairingForbidden:
-            return "Pair With Existing Pairing Is Forbidden"
+            return "Pairing for uri already exist - Action Forbidden"
         }
     }
 }


### PR DESCRIPTION
close #181 
Add limits to call pair function withe the same uri
Add preSettled, acknowledged status for settled pairing
allows `handleSessionApprove` to be called by non-controller only
refactor pairing engine